### PR TITLE
feat: Header 컴포넌트 재사용성 개선 #64

### DIFF
--- a/client/src/components/atoms/Icon/Icon.tsx
+++ b/client/src/components/atoms/Icon/Icon.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import * as S from './styled';
-import { FaArrowLeft, FaSearch, FaBars, FaRegHeart, FaHeart } from 'react-icons/fa';
+import { AiOutlineNotification } from 'react-icons/ai';
+import { FaArrowLeft, FaSearch, FaBars, FaRegHeart, FaHeart, FaUndoAlt } from 'react-icons/fa';
+import { IoMdCloseCircleOutline } from 'react-icons/io';
 import { IconType } from '@utils/constants';
 
 type Props = {
@@ -21,6 +23,12 @@ const findIcon = (iconName: string) => {
       return <FaRegHeart />;
     case IconType.HEART:
       return <FaHeart />;
+    case IconType.REFRESH:
+      return <FaUndoAlt />;
+    case IconType.CLOSE:
+      return <IoMdCloseCircleOutline />;
+    case IconType.NOTIFICATION:
+      return <AiOutlineNotification />;
     default:
       return;
   }

--- a/client/src/components/modules/Header/Header.tsx
+++ b/client/src/components/modules/Header/Header.tsx
@@ -5,24 +5,35 @@ import Logo from '@components/atoms/Logo';
 import { IconType } from '@utils/constants';
 
 type Props = {
-  children: React.FC;
+  left?: string;
+  main?: string;
+  right?: Array<string>;
 };
 
 const onClick = () => {
   console.log('hello world');
 };
 
-export const Header: React.FC = () => {
+export const Header: React.FC<Props> = ({ left, main, right }) => {
   return (
     <S.Header className="header">
-      <Icon icon={IconType.ARROW_LEFT} size={1.5} onClick={onClick} />
-      <div className="logo-wrap">
-        <Logo alt="logo" src="logo" size={5} />
-      </div>
-      <div className="wrap">
-        <Icon icon={IconType.SEARCH} size={1.5} onClick={onClick} />
-        <Icon icon={IconType.BARS} size={1.5} onClick={onClick} />
-      </div>
+      {left && (
+        <div className="left-wrap">
+          <Icon icon={left} size={1.1} onClick={onClick} />
+        </div>
+      )}
+      {main && (
+        <div className="main-wrap">
+          {main === 'Logo' ? <Logo alt="logo" src="logo" size={4} /> : `${main}`}
+        </div>
+      )}
+      {right && (
+        <div className="right-wrap">
+          {right.map((iconType) => (
+            <Icon icon={iconType} size={1.1} onClick={onClick} />
+          ))}
+        </div>
+      )}
     </S.Header>
   );
 };

--- a/client/src/components/modules/Header/Header.tsx
+++ b/client/src/components/modules/Header/Header.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 import * as S from './styled';
 import Icon from '@components/atoms/Icon';
 import Logo from '@components/atoms/Logo';
-import { IconType } from '@utils/constants';
+import { HeaderMainType } from '@utils/constants';
+
+type MainType = {
+  type: string;
+  content?: string;
+};
 
 type Props = {
   left?: string;
-  main?: string;
+  main?: MainType;
   right?: Array<string>;
 };
 
@@ -24,7 +29,13 @@ export const Header: React.FC<Props> = ({ left, main, right }) => {
       )}
       {main && (
         <div className="main-wrap">
-          {main === 'Logo' ? <Logo alt="logo" src="logo" size={4} /> : `${main}`}
+          {main.type === HeaderMainType.LOGO ? (
+            <Logo alt="logo" src="logo" size={4} />
+          ) : main.type === HeaderMainType.SEARCH_BAR ? (
+            `--검색 인풋 구현--`
+          ) : (
+            `${main.content}`
+          )}
         </div>
       )}
       {right && (

--- a/client/src/components/modules/Header/styled.tsx
+++ b/client/src/components/modules/Header/styled.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const Header = styled.header`
   position: relative;
   display: flex;
+  min-height: 24px;
   justify-content: space-between;
   align-items: center;
   padding: 1rem;

--- a/client/src/components/modules/Header/styled.tsx
+++ b/client/src/components/modules/Header/styled.tsx
@@ -7,18 +7,24 @@ export const Header = styled.header`
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
-  & > div.logo-wrap {
+  & > div.left-wrap {
+    display: flex;
+    justify-content: space-between;
+  }
+  & > div.main-wrap {
     display: flex;
     position: absolute;
+    font-weight: bold;
+    font-size: 1rem;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
   }
-  & > div.wrap {
+  & > div.right-wrap {
     display: flex;
     justify-content: space-between;
-    & > :first-child {
-      margin-right: 1rem;
+    & > :last-child {
+      margin-left: 1rem;
     }
   }
 `;

--- a/client/src/pages/MainPage/MainPage.tsx
+++ b/client/src/pages/MainPage/MainPage.tsx
@@ -1,11 +1,33 @@
 import React from 'react';
 import Header from '@components/modules/Header';
 import SlidableContainer from '@components/modules/SlidableContainer';
+import { IconType } from '@utils/constants';
 
 const MainPage: React.FC = () => {
   return (
     <div>
-      <Header />
+      {/* main */}
+      <Header
+        left={IconType.ARROW_LEFT}
+        main="Logo"
+        right={[IconType.SEARCH, IconType.BARS]}
+      />{' '}
+      {/* back & title */}
+      <Header left={IconType.ARROW_LEFT} main="장바구니" />
+      {/* back */}
+      <Header left={IconType.ARROW_LEFT} />
+      {/* back & title */}
+      <Header left={IconType.CLOSE} main="이벤트" />
+      {/* category */}
+      <Header
+        left={IconType.ARROW_LEFT}
+        main="정육,수산,계란"
+        right={[IconType.SEARCH, IconType.BARS]}
+      />{' '}
+      {/* TODO: SearchBar */}
+      <Header left={IconType.ARROW_LEFT} main="SearchBar" right={[IconType.SEARCH]} />{' '}
+      {/* OrderList */}
+      <Header left={IconType.NOTIFICATION} main="주문내역" right={[IconType.REFRESH]} />{' '}
       <SlidableContainer />
     </div>
   );

--- a/client/src/pages/MainPage/MainPage.tsx
+++ b/client/src/pages/MainPage/MainPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Header from '@components/modules/Header';
 import SlidableContainer from '@components/modules/SlidableContainer';
-import { IconType } from '@utils/constants';
+import { IconType, HeaderMainType } from '@utils/constants';
 
 const MainPage: React.FC = () => {
   return (
@@ -9,25 +9,36 @@ const MainPage: React.FC = () => {
       {/* main */}
       <Header
         left={IconType.ARROW_LEFT}
-        main="Logo"
+        main={{ type: HeaderMainType.LOGO }}
         right={[IconType.SEARCH, IconType.BARS]}
       />{' '}
       {/* back & title */}
-      <Header left={IconType.ARROW_LEFT} main="장바구니" />
+      <Header
+        left={IconType.ARROW_LEFT}
+        main={{ type: HeaderMainType.TEXT, content: '장바구니' }}
+      />
       {/* back */}
       <Header left={IconType.ARROW_LEFT} />
       {/* back & title */}
-      <Header left={IconType.CLOSE} main="이벤트" />
+      <Header left={IconType.CLOSE} main={{ type: HeaderMainType.TEXT, content: '이벤트' }} />
       {/* category */}
       <Header
         left={IconType.ARROW_LEFT}
-        main="정육,수산,계란"
+        main={{ type: HeaderMainType.TEXT, content: '정육・수산・계란' }}
         right={[IconType.SEARCH, IconType.BARS]}
       />{' '}
       {/* TODO: SearchBar */}
-      <Header left={IconType.ARROW_LEFT} main="SearchBar" right={[IconType.SEARCH]} />{' '}
+      <Header
+        left={IconType.ARROW_LEFT}
+        main={{ type: HeaderMainType.SEARCH_BAR }}
+        right={[IconType.SEARCH]}
+      />{' '}
       {/* OrderList */}
-      <Header left={IconType.NOTIFICATION} main="주문내역" right={[IconType.REFRESH]} />{' '}
+      <Header
+        left={IconType.NOTIFICATION}
+        main={{ type: HeaderMainType.TEXT, content: '주문내역' }}
+        right={[IconType.REFRESH]}
+      />{' '}
       <SlidableContainer />
     </div>
   );

--- a/client/src/utils/constants.tsx
+++ b/client/src/utils/constants.tsx
@@ -1,12 +1,18 @@
 export enum IconType {
   ARROW_LEFT = 'ArrowLeft',
-  SEARCH = 'Search',
   BARS = 'Bars',
-  REG_HEART = 'RegHeart',
+  CLOSE = 'Close',
   HEART = 'Heart',
+  NOTIFICATION = 'Notification',
+  REFRESH = 'Refresh',
+  REG_HEART = 'RegHeart',
+  SEARCH = 'Search',
   'ArrowLeft' = ARROW_LEFT,
-  'Search' = SEARCH,
   'Bars' = BARS,
+  'Close' = CLOSE,
+  'Heart' = HEART,
+  'Notification' = NOTIFICATION,
+  'Refresh' = REFRESH,
   'RegHeart' = REG_HEART,
-  'Heart' = HEART
+  'Search' = SEARCH,
 }

--- a/client/src/utils/constants.tsx
+++ b/client/src/utils/constants.tsx
@@ -16,3 +16,9 @@ export enum IconType {
   'RegHeart' = REG_HEART,
   'Search' = SEARCH,
 }
+
+export enum HeaderMainType {
+  LOGO = 'Logo',
+  TEXT = 'Text',
+  SEARCH_BAR = 'SearchBar',
+}


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

Header 컴포넌트에 left, main, right를 props로 받아 재사용성을 개선했습니다.
- left: IconType(string)
- main: MainType
- right: Array<IconType>

TODO: 검색 창은 나중에 구현해야 합니다.
상수를 분리했는데, 코드 가독성이 떨어져서 검토 부탁드립니다.

## 체크리스트

### 리뷰어 1 - 이종구

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #64 

## 기타(스크린샷 등)

> PR에 대한 이해를 돕기 위한 자료가 있다면 추가합니다.

### B마트 헤더

![image](https://user-images.githubusercontent.com/48426991/90127396-11b80580-dda0-11ea-963c-0cc0660e1058.png)

### 구현한 헤더
![image](https://user-images.githubusercontent.com/48426991/90127432-209eb800-dda0-11ea-8dde-cedd101e3c66.png)
