### PR TITLE
Auth api#22

### DIFF
--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -12,6 +12,7 @@ const emailLogin = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const emailUser = await LoginProvider.findOne({
       attributes: ['id', 'email', 'provider', 'password', 'userId'],
+      include: { model: User, as: 'user' },
       where: {
         email: body.email,
         provider: 'email',
@@ -23,16 +24,9 @@ const emailLogin = async (req: Request, res: Response, next: NextFunction) => {
     if (emailUser.password !== crypto.createHash('sha256').update(body.password).digest('base64'))
       throw new CustomError(HttpStatus.BAD_REQUEST, 'not matched password', '');
 
-    const user = await User.findOne({
-      attributes: ['id', 'email', 'username', 'imgUrl', 'isAdmin'],
-      where: {
-        id: emailUser.getDataValue('userId'),
-      },
-    });
-
     const token = jwt.sign(
       {
-        data: user,
+        data: emailUser.getDataValue('user'),
       },
       jwtSecret,
       { expiresIn: tokenExpiresIn }

--- a/server/src/controllers/auth-controller.ts
+++ b/server/src/controllers/auth-controller.ts
@@ -1,0 +1,158 @@
+import { Request, Response, NextFunction } from 'express';
+import HttpStatus from 'http-status';
+import crypto from 'crypto';
+import jwt from 'jsonwebtoken';
+import { LoginProvider, User, Cart } from '../models';
+import { jwtSecret, tokenExpiresIn } from '../config/constants';
+import { JsonResponse } from '../modules/utils';
+import CustomError from '../modules/exception/custom-error';
+
+const emailLogin = async (req: Request, res: Response, next: NextFunction) => {
+  const { body } = req;
+  try {
+    const emailUser = await LoginProvider.findOne({
+      attributes: ['id', 'email', 'provider', 'password', 'userId'],
+      where: {
+        email: body.email,
+        provider: 'email',
+      },
+    });
+
+    if (!emailUser)
+      throw new CustomError(HttpStatus.BAD_REQUEST, `no email user with ${body.email}`, '');
+    if (emailUser.password !== crypto.createHash('sha256').update(body.password).digest('base64'))
+      throw new CustomError(HttpStatus.BAD_REQUEST, 'not matched password', '');
+
+    const user = await User.findOne({
+      attributes: ['id', 'email', 'username', 'imgUrl', 'isAdmin'],
+      where: {
+        id: emailUser.getDataValue('userId'),
+      },
+    });
+
+    const token = jwt.sign(
+      {
+        data: user,
+      },
+      jwtSecret,
+      { expiresIn: tokenExpiresIn }
+    );
+
+    res
+      .cookie('authorization', token, {
+        // 30 분 뒤 만료
+        expires: new Date(Date.now() + 30 * 60 * 1000),
+      })
+      .status(HttpStatus.OK)
+      .json(JsonResponse(HttpStatus.OK, `Log in success ${req.body.email}`, { completed: true }));
+  } catch (err) {
+    next(err);
+  }
+};
+
+const emailSignUp = async (req: Request, res: Response, next: NextFunction) => {
+  const { body } = req;
+  body.password = crypto.createHash('sha256').update(body.password).digest('base64');
+  try {
+    const existsUser = await LoginProvider.findOne({
+      attributes: ['id', 'email', 'provider', 'password', 'userId'],
+      where: {
+        email: body.email,
+        provider: 'email',
+      },
+    });
+    if (existsUser) {
+      throw new CustomError(HttpStatus.BAD_REQUEST, `already exists email ${body.email}`, '');
+    } else {
+      const response = await User.findOrCreate({
+        attributes: ['id', 'username', 'email'],
+        where: {
+          email: body.email,
+        },
+        defaults: { username: body.username },
+      });
+
+      const user = response[0];
+      const isCreated = response[1];
+
+      if (isCreated) Cart.create({ userId: user.id });
+      console.info(`user ${isCreated ? 'created' : 'found'}: ${user.id}`);
+
+      const emailUserData = {
+        id: user.id.toString(),
+        email: body.email,
+        password: body.password,
+        provider: 'email',
+        userId: user.id,
+      };
+      const emailUser = await LoginProvider.create(emailUserData);
+
+      const token = jwt.sign(
+        {
+          data: user,
+        },
+        jwtSecret,
+        { expiresIn: tokenExpiresIn }
+      );
+      res
+        .cookie('authorization', token, {
+          // 30 분 뒤 만료
+          expires: new Date(Date.now() + 30 * 60 * 1000),
+        })
+        .status(HttpStatus.CREATED)
+        .json(
+          JsonResponse(HttpStatus.CREATED, `created user success email(${body.email})`, emailUser)
+        );
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+const googleRedirect = async (req: Request, res: Response, next: NextFunction) => {
+  const googleUser: any = req.user;
+
+  const response = await User.findOrCreate({
+    attributes: ['id', 'username', 'email'],
+    where: {
+      email: googleUser._json.email,
+    },
+    defaults: { username: googleUser.displayName },
+  });
+
+  const user = response[0];
+  const isCreated = response[1];
+
+  if (isCreated) Cart.create({ userId: user.id });
+  console.info(`user ${isCreated ? 'created' : 'found'}: ${user.id}`);
+
+  await LoginProvider.findOrCreate({
+    attributes: ['id', 'username', 'email'],
+    where: {
+      email: googleUser._json.email,
+      provider: 'google',
+    },
+    defaults: { userId: user.id },
+  });
+
+  const token = jwt.sign(
+    {
+      data: user,
+    },
+    jwtSecret,
+    { expiresIn: tokenExpiresIn }
+  );
+
+  res.cookie('authorization', token, {
+    // 30 분 뒤 만료
+    expires: new Date(Date.now() + 30 * 60 * 1000),
+  });
+
+  res.redirect('/');
+};
+
+export default {
+  emailSignUp,
+  emailLogin,
+  googleRedirect,
+};

--- a/server/src/controllers/cart-controller.ts
+++ b/server/src/controllers/cart-controller.ts
@@ -1,0 +1,192 @@
+import { Request, Response, NextFunction } from 'express';
+import { Op } from 'sequelize';
+import HttpStatus from 'http-status';
+import { Cart, CartProduct, Product } from '../models';
+import { JsonResponse } from '../modules/utils';
+import CustomError from '../modules/exception/custom-error';
+
+//추후에 토큰의 유저 정보를 이용한 api로 수정 필요
+
+const insertCartProduct = async (req: Request, res: Response, next: NextFunction) => {
+  const { body } = req;
+
+  try {
+    const cart = await Cart.findOne({
+      attributes: ['id'],
+      where: {
+        [Op.and]: [
+          { userId: body.userId },
+          {
+            purchasedAt: {
+              [Op.is]: null,
+            },
+          },
+        ],
+      },
+    });
+
+    if (!cart)
+      throw new CustomError(HttpStatus.BAD_REQUEST, `no cart with userId: ${body.userId}`, '');
+
+    delete body.userId;
+    body.cartId = cart.id;
+    const cartProduct = await CartProduct.create(body);
+
+    res
+      .status(HttpStatus.CREATED)
+      .json(
+        JsonResponse(HttpStatus.CREATED, `cart product created: ${cartProduct.id}`, cartProduct)
+      );
+  } catch (err) {
+    next(err);
+  }
+};
+
+const findByUserId = async (req: Request, res: Response, next: NextFunction) => {
+  const { params } = req;
+  const paramId = parseInt(params.id);
+
+  try {
+    const cart = await Cart.findOne({
+      attributes: ['id'],
+      where: {
+        [Op.and]: [
+          { userId: paramId },
+          {
+            purchasedAt: {
+              [Op.is]: null,
+            },
+          },
+        ],
+      },
+    });
+    if (!cart) throw new CustomError(HttpStatus.BAD_REQUEST, `no cart with id ${paramId}`, '');
+    req.params.id = cart.id.toString();
+    findByCartId(req, res, next);
+  } catch (err) {
+    next(err);
+  }
+};
+
+const findByCartId = async (req: Request, res: Response, next: NextFunction) => {
+  const { params } = req;
+  const paramId = params.id;
+
+  try {
+    const cartProducts = await CartProduct.findAll({
+      attributes: ['id', 'productId', 'cartId', 'count'],
+      include: { model: Product, as: 'product' },
+      where: {
+        [Op.and]: [
+          { cartId: paramId },
+          {
+            deletedAt: {
+              [Op.is]: null,
+            },
+          },
+        ],
+      },
+    });
+
+    res
+      .status(HttpStatus.OK)
+      .json(
+        JsonResponse(HttpStatus.OK, `cart products count: ${cartProducts.length}`, cartProducts)
+      );
+  } catch (err) {
+    next(err);
+  }
+};
+
+const updateCount = async (req: Request, res: Response, next: NextFunction) => {
+  const { params, body } = req;
+  const paramId = parseInt(params.id);
+  const count = body.count;
+
+  try {
+    const cartProduct = await CartProduct.findByPk(paramId);
+    if (!cartProduct)
+      throw new CustomError(HttpStatus.BAD_REQUEST, `no cart product with id ${paramId}`, '');
+    cartProduct.update({ count: count });
+
+    res.status(HttpStatus.OK).json(
+      JsonResponse(HttpStatus.OK, `cart product count updated: ${count}`, {
+        completed: true,
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+const purchase = async (req: Request, res: Response, next: NextFunction) => {
+  const { params } = req;
+  const paramId = parseInt(params.id);
+  const now = new Date();
+
+  try {
+    let cart = await Cart.findByPk(paramId);
+    if (!cart) throw new CustomError(HttpStatus.BAD_REQUEST, `no cart with id ${paramId}`, '');
+    cart.update({ purchasedAt: now });
+    Cart.create({ userId: cart.getDataValue('userId') });
+
+    res.status(HttpStatus.OK).json(
+      JsonResponse(HttpStatus.OK, `cart purchased: ${paramId}`, {
+        completed: true,
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+const softDeleteCartProduct = async (req: Request, res: Response, next: NextFunction) => {
+  const { params } = req;
+  const paramId = parseInt(params.id);
+  const now = new Date();
+
+  try {
+    const cartProduct = await CartProduct.findByPk(paramId);
+    if (!cartProduct)
+      throw new CustomError(HttpStatus.BAD_REQUEST, `no cart product with id ${paramId}`, '');
+    cartProduct.update({ deletedAt: now });
+
+    res.status(HttpStatus.OK).json(
+      JsonResponse(HttpStatus.OK, `cart product soft deleted: ${paramId}`, {
+        completed: true,
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+const softDeleteCart = async (req: Request, res: Response, next: NextFunction) => {
+  const { params } = req;
+  const paramId = parseInt(params.id);
+  const now = new Date();
+
+  try {
+    const cart = await Cart.findByPk(paramId);
+    if (!cart) throw new CustomError(HttpStatus.BAD_REQUEST, `no cart with id ${paramId}`, '');
+    cart.update({ deletedAt: now });
+
+    res.status(HttpStatus.OK).json(
+      JsonResponse(HttpStatus.OK, `cart product soft deleted: ${paramId}`, {
+        completed: true,
+      })
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default {
+  insertCartProduct,
+  findByUserId,
+  findByCartId,
+  updateCount,
+  purchase,
+  softDeleteCartProduct,
+  softDeleteCart,
+};

--- a/server/src/controllers/cart-controller.ts
+++ b/server/src/controllers/cart-controller.ts
@@ -172,7 +172,7 @@ const softDeleteCart = async (req: Request, res: Response, next: NextFunction) =
     cart.update({ deletedAt: now });
 
     res.status(HttpStatus.OK).json(
-      JsonResponse(HttpStatus.OK, `cart product soft deleted: ${paramId}`, {
+      JsonResponse(HttpStatus.OK, `cart soft deleted: ${paramId}`, {
         completed: true,
       })
     );

--- a/server/src/controllers/index.ts
+++ b/server/src/controllers/index.ts
@@ -1,5 +1,13 @@
 import ProductController from './product-controller';
 import CategoryController from './category-controller';
 import SubCategoryController from './sub-category-controller';
+import CartController from './cart-controller';
+import AuthController from './auth-controller';
 
-export { ProductController, CategoryController, SubCategoryController };
+export {
+  ProductController,
+  CategoryController,
+  SubCategoryController,
+  CartController,
+  AuthController,
+};

--- a/server/src/controllers/sub-category-controller.ts
+++ b/server/src/controllers/sub-category-controller.ts
@@ -1,8 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 import { Op } from 'sequelize';
+import HttpStatus from 'http-status';
 import { SubCategory } from '../models';
 import { JsonResponse } from '../modules/utils';
-import HttpStatus from 'http-status';
+import CustomError from '../modules/exception/custom-error';
 
 const create = async (req: Request, res: Response, next: NextFunction) => {
   const { body } = req;
@@ -54,10 +55,14 @@ const softDelete = async (req: Request, res: Response, next: NextFunction) => {
   const now = new Date();
 
   try {
-    const subCategory = await SubCategory.update({ deletedAt: now }, { where: { id: paramId } });
+    const subCategory = await SubCategory.findByPk(paramId);
+    if (!subCategory)
+      throw new CustomError(HttpStatus.BAD_REQUEST, `no sub-category with id ${paramId}`, '');
+    subCategory.update({ deletedAt: now });
+
     res.status(HttpStatus.OK).json(
       JsonResponse(HttpStatus.OK, `sub category soft deleted: ${paramId}`, {
-        completed: subCategory[0],
+        completed: subCategory[0] ? true : false,
       })
     );
   } catch (err) {
@@ -70,10 +75,14 @@ const update = async (req: Request, res: Response, next: NextFunction) => {
   const paramId = parseInt(params.id);
 
   try {
-    const subCategory = await SubCategory.update(body, { where: { id: paramId } });
+    const subCategory = await SubCategory.findByPk(paramId);
+    if (!subCategory)
+      throw new CustomError(HttpStatus.BAD_REQUEST, `no sub-category with id ${paramId}`, '');
+    subCategory.update(body);
+
     res.status(HttpStatus.OK).json(
       JsonResponse(HttpStatus.OK, `sub category updated: ${paramId}`, {
-        completed: subCategory[0],
+        completed: subCategory[0] ? true : false,
       })
     );
   } catch (err) {

--- a/server/src/models/cart-product.ts
+++ b/server/src/models/cart-product.ts
@@ -1,0 +1,34 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../modules/database';
+
+class CartProduct extends Model {
+  public id!: number;
+  public count!: number;
+  public deletedAt!: Date | null;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+CartProduct.init(
+  {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true,
+    },
+    count: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      allowNull: false,
+      defaultValue: 1,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  { timestamps: true, tableName: 'cart_product', sequelize }
+);
+
+export default CartProduct;

--- a/server/src/models/cart-product.ts
+++ b/server/src/models/cart-product.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../modules/database';
+import Product from './product';
 
 class CartProduct extends Model {
   public id!: number;
@@ -30,5 +31,11 @@ CartProduct.init(
   },
   { timestamps: true, tableName: 'cart_product', sequelize }
 );
+
+CartProduct.belongsTo(Product, {
+  targetKey: 'id',
+  foreignKey: { name: 'productId', allowNull: false },
+  as: 'product',
+});
 
 export default CartProduct;

--- a/server/src/models/cart.ts
+++ b/server/src/models/cart.ts
@@ -1,0 +1,41 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../modules/database';
+import CartProduct from './cart-product';
+
+class Cart extends Model {
+  public id!: number;
+  public purchasedAt!: Date | null;
+  public deletedAt!: Date | null;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+Cart.init(
+  {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true,
+    },
+    purchasedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  { timestamps: true, tableName: 'cart', sequelize }
+);
+
+Cart.hasMany(CartProduct, {
+  sourceKey: 'id',
+  foreignKey: { name: 'cartId', allowNull: false },
+  as: 'cartProducts',
+});
+
+export default Cart;

--- a/server/src/models/category.ts
+++ b/server/src/models/category.ts
@@ -41,7 +41,7 @@ Category.init(
 Category.hasMany(SubCategory, {
   sourceKey: 'id',
   foreignKey: { name: 'categoryId', allowNull: false },
-  as: 'sub_categories',
+  as: 'subCategories',
 });
 
 export default Category;

--- a/server/src/models/index.ts
+++ b/server/src/models/index.ts
@@ -1,5 +1,9 @@
 import Category from './category';
 import SubCategory from './sub-category';
 import Product from './product';
+import User from './user';
+import Cart from './cart';
+import CartProduct from './cart-product';
+import LoginProvider from './login-provider';
 
-export { Category, SubCategory, Product };
+export { Category, SubCategory, Product, User, Cart, CartProduct, LoginProvider };

--- a/server/src/models/login-provider.ts
+++ b/server/src/models/login-provider.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../modules/database';
+import User from './user';
 
 class LoginProvider extends Model {
   public id!: string;
@@ -32,5 +33,11 @@ LoginProvider.init(
   },
   { timestamps: true, tableName: 'login_provider', sequelize }
 );
+
+LoginProvider.belongsTo(User, {
+  targetKey: 'id',
+  foreignKey: { name: 'userId', allowNull: false },
+  as: 'user',
+});
 
 export default LoginProvider;

--- a/server/src/models/login-provider.ts
+++ b/server/src/models/login-provider.ts
@@ -1,0 +1,36 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../modules/database';
+
+class LoginProvider extends Model {
+  public id!: string;
+  public email!: string;
+  public provider!: string;
+  public password?: string;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+LoginProvider.init(
+  {
+    id: {
+      type: DataTypes.STRING(100),
+      primaryKey: true,
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING(100),
+      allowNull: false,
+    },
+    provider: {
+      type: DataTypes.STRING(45),
+      allowNull: false,
+    },
+    password: {
+      type: DataTypes.STRING(200),
+      allowNull: true,
+    },
+  },
+  { timestamps: true, tableName: 'login_provider', sequelize }
+);
+
+export default LoginProvider;

--- a/server/src/models/product.ts
+++ b/server/src/models/product.ts
@@ -58,10 +58,4 @@ Product.init(
   { timestamps: true, tableName: 'product', sequelize }
 );
 
-Product.hasMany(CartProduct, {
-  sourceKey: 'id',
-  foreignKey: { name: 'productId', allowNull: false },
-  as: 'cartProducts',
-});
-
 export default Product;

--- a/server/src/models/product.ts
+++ b/server/src/models/product.ts
@@ -1,5 +1,6 @@
 import { DataTypes, Model } from 'sequelize';
 import { sequelize } from '../modules/database';
+import CartProduct from './cart-product';
 
 class Product extends Model {
   public id!: number;
@@ -56,5 +57,11 @@ Product.init(
   },
   { timestamps: true, tableName: 'product', sequelize }
 );
+
+Product.hasMany(CartProduct, {
+  sourceKey: 'id',
+  foreignKey: { name: 'productId', allowNull: false },
+  as: 'cartProducts',
+});
 
 export default Product;

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -1,0 +1,58 @@
+import { DataTypes, Model } from 'sequelize';
+import { sequelize } from '../modules/database';
+import LoginProvider from './login-provider';
+import Cart from './cart';
+
+class User extends Model {
+  public id!: number;
+  public username!: string;
+  public email!: string;
+  public imgUrl?: string;
+  public isAdmin!: boolean;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+}
+
+User.init(
+  {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      primaryKey: true,
+      allowNull: false,
+      autoIncrement: true,
+    },
+    username: {
+      type: DataTypes.STRING(45),
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING(100),
+      unique: true,
+      allowNull: false,
+    },
+    imgUrl: {
+      type: DataTypes.STRING(200),
+      allowNull: true,
+    },
+    isAdmin: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+  },
+  { timestamps: true, tableName: 'user', sequelize }
+);
+
+User.hasMany(LoginProvider, {
+  sourceKey: 'id',
+  foreignKey: { name: 'userId', allowNull: false },
+  as: 'loginProviders',
+});
+
+User.hasMany(Cart, {
+  sourceKey: 'id',
+  foreignKey: { name: 'userId', allowNull: false },
+  as: 'carts',
+});
+
+export default User;

--- a/server/src/models/user.ts
+++ b/server/src/models/user.ts
@@ -43,12 +43,6 @@ User.init(
   { timestamps: true, tableName: 'user', sequelize }
 );
 
-User.hasMany(LoginProvider, {
-  sourceKey: 'id',
-  foreignKey: { name: 'userId', allowNull: false },
-  as: 'loginProviders',
-});
-
 User.hasMany(Cart, {
   sourceKey: 'id',
   foreignKey: { name: 'userId', allowNull: false },

--- a/server/src/routers/auth-router.ts
+++ b/server/src/routers/auth-router.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import passport from 'passport';
+import { AuthController } from '../controllers';
+
+const router = Router();
+
+router.post('/email', AuthController.emailLogin);
+router.post('/email/signup', AuthController.emailSignUp);
+router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
+router.get('/google/redirect', passport.authenticate('google'), AuthController.googleRedirect);
+
+export default router;

--- a/server/src/routers/cart-router.ts
+++ b/server/src/routers/cart-router.ts
@@ -6,7 +6,7 @@ const router = Router();
 router.post('/', CartController.insertCartProduct);
 
 router.get('/user/:id', CartController.findByUserId);
-router.get('/cart/:id', CartController.findByCartId);
+router.get('/:id', CartController.findByCartId);
 
 router.patch('/:id', CartController.updateCount);
 router.patch('/purchase/:id', CartController.purchase);

--- a/server/src/routers/cart-router.ts
+++ b/server/src/routers/cart-router.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { CartController } from '../controllers';
+
+const router = Router();
+
+router.post('/', CartController.insertCartProduct);
+
+router.get('/user/:id', CartController.findByUserId);
+router.get('/cart/:id', CartController.findByCartId);
+
+router.patch('/:id', CartController.updateCount);
+router.patch('/purchase/:id', CartController.purchase);
+
+router.delete('/product/:id', CartController.softDeleteCartProduct);
+router.delete('/:id', CartController.softDeleteCart);
+
+export default router;

--- a/server/src/routers/index.ts
+++ b/server/src/routers/index.ts
@@ -2,10 +2,14 @@ import { Router } from 'express';
 import CategoryRouter from './category-router';
 import SubCategoryRouter from './sub-category-router';
 import ProductRouter from './product-router';
+import CartRouter from './cart-router';
+import AuthRouter from './auth-router';
 
 const router = Router();
 router.use('/category', CategoryRouter);
 router.use('/sub_category', SubCategoryRouter);
 router.use('/product', ProductRouter);
+router.use('/auth', AuthRouter);
+router.use('/cart', CartRouter);
 
 export default router;

--- a/server/src/routers/sub-category-router.ts
+++ b/server/src/routers/sub-category-router.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express';
 import { SubCategoryController } from '../controllers';
-import subCategoryController from 'src/controllers/sub-category-controller';
 
 const router = Router();
 
@@ -9,6 +8,6 @@ router.get('/:limit', SubCategoryController.findAll);
 router.get('/cat/:categoryId/:limit', SubCategoryController.findByCategoryId);
 router.put('/:id', SubCategoryController.update);
 router.delete('/:id', SubCategoryController.softDelete);
-router.post('/bulkcreate', subCategoryController.bulkCreate);
+router.post('/bulkcreate', SubCategoryController.bulkCreate);
 
 export default router;


### PR DESCRIPTION
## PR 요약
**auth**
- email 유저 회원가입
- email을 통한 로그인
- google 로그인 리다이렉트
- google을 통한 로그인

**cart**
- 장바구니 담기 api
- userId를 통한 장바구니 아이템 조회 api
- cartId를 통한 장바구니 아이템 조회 api
- 장바구니 아이템 개수 업데이트 api
- 장바구니 아이템들 구매 api
- 구매내역 삭제 api
- 장바구니 아이템 삭제 api

**refactor**
- update: findByPk 이후 instance update 방식으로 개선
- cart-product와 product 관계
- login-provider와 user 관계를 hasMany에서 belongsTo로 변경
- 전자 조회시 후자 모델을 include 해서 조회할 수 있게 됨

## 체크리스트

### 리뷰어 1 - 김명성

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈
- resolve #22

## 참고자료
🔗 [sequelize 공식문서 (belongsTo)](https://sequelize.org/master/manual/typescript.html)
🔗 [포스트맨 링크](https://documenter.getpostman.com/view/2322914/T1LPC6xM?version=latest)