### PR TITLE
feat: TabViewContainer API 연결 및 currentTab 표시 #106

### DIFF
--- a/client/scripts/bulk_create_category.sh
+++ b/client/scripts/bulk_create_category.sh
@@ -1,4 +1,4 @@
-url='http://localhost:4000'
+url='http://localhost:3000'
 
 echo start category bulk
 echo url for api: ${url}

--- a/client/scripts/bulk_create_product.sh
+++ b/client/scripts/bulk_create_product.sh
@@ -1,4 +1,4 @@
-url='http://localhost:4000'
+url='http://localhost:3000'
 base_id=$1   #첫번째 하위 카테고리 id 533
 # init each sub category id with base_id
 ########################################

--- a/client/scripts/bulk_create_sub_category.sh
+++ b/client/scripts/bulk_create_sub_category.sh
@@ -1,4 +1,4 @@
-url='http://localhost:4000'
+url='http://localhost:3000'
 base_id=$1   #첫번째 카테고리 id
 # init each category id with base_id
 ########################################

--- a/client/src/components/templates/SlidableContainer/SlidableContainer.tsx
+++ b/client/src/components/templates/SlidableContainer/SlidableContainer.tsx
@@ -1,18 +1,8 @@
 import React from 'react';
 import * as S from './styled';
 import ProductCard from '@components/modules/ProductCard';
+import { ProductType } from '@pages/index';
 import ContainerHeader from '@components/modules/ContainerHeader';
-
-export type ProductType = {
-  id: number;
-  name: string;
-  price: number;
-  content: string;
-  discount: number;
-  outOfStockAt: Date | null;
-  subCategoryId: number;
-  imgUrl: string;
-};
 
 type ProductArrType = Array<ProductType>;
 

--- a/client/src/components/templates/TabViewContainer/TabViewContainer.tsx
+++ b/client/src/components/templates/TabViewContainer/TabViewContainer.tsx
@@ -3,6 +3,7 @@ import * as S from './styled';
 import ProductCard from '@components/modules/ProductCard';
 import { ProductType } from '@pages/index';
 import ContainerHeader from '@components/modules/ContainerHeader';
+import { TabViewProductsCount } from '@utils/constants';
 
 type ProductArrType = Array<ProductType>;
 
@@ -13,7 +14,9 @@ type Props = {
 
 export const TabViewContainer: React.FC<Props> = ({ products, setSelect }) => {
   const [currentTab, setCurrentTab] = useState<number>(0);
-  const imageRefs = Array.from({ length: 4 }, () => useRef<HTMLDivElement>(null));
+  const imageRefs = Array.from({ length: TabViewProductsCount }, () =>
+    useRef<HTMLDivElement>(null)
+  );
 
   useEffect(() => {
     imageRefs[0].current?.classList.add('current-tab');

--- a/client/src/components/templates/TabViewContainer/TabViewContainer.tsx
+++ b/client/src/components/templates/TabViewContainer/TabViewContainer.tsx
@@ -1,58 +1,56 @@
-import React from 'react';
+import React, { useState, useEffect, useRef, MouseEvent } from 'react';
 import * as S from './styled';
-import ContainerHeader from '@components/modules/ContainerHeader';
 import ProductCard from '@components/modules/ProductCard';
+import { ProductType } from '@pages/index';
+import ContainerHeader from '@components/modules/ContainerHeader';
+
+type ProductArrType = Array<ProductType>;
 
 type Props = {
-  // products: ProductArrType; <--- 나중에 이걸로 가져와서 map으로 처리.
+  products: ProductArrType;
   setSelect: Function;
 };
 
-// 임시 데이터
-const item = {
-  content: '',
-  discount: 8,
-  id: 608,
-  imgUrl:
-    'http://thumbnail10.coupangcdn.com/thumbnails/remote/230x230ex/image/retail/images/432437954992902-8c4ac85e-1400-4da1-8d45-62bda8b9bd79.jpg',
-  name: '친환경 인증 팽이버섯, 150g, 3팩',
-  outOfStockAt: null,
-  price: 1480,
-  subCategoryId: 2,
-};
+export const TabViewContainer: React.FC<Props> = ({ products, setSelect }) => {
+  const [currentTab, setCurrentTab] = useState<number>(0);
+  const imageRefs = Array.from({ length: 4 }, () => useRef<HTMLDivElement>(null));
 
-export const TabViewContainer: React.FC<Props> = ({ setSelect }) => {
+  useEffect(() => {
+    imageRefs[0].current?.classList.add('current-tab');
+  }, []);
+
+  const onTabClickHandler = (event: MouseEvent) => {
+    const target = (event.target as any).id;
+    resetCurrentTab(target);
+    setCurrentTab(target);
+  };
+
+  const resetCurrentTab = (target: number) => {
+    imageRefs.forEach((ref) => {
+      ref.current?.classList.remove('current-tab');
+    });
+    imageRefs[target].current?.classList.add('current-tab');
+    return imageRefs[target].current;
+  };
+
   return (
     <S.TabViewContainer>
       <ContainerHeader moreBtn>지금사면 ⚡️번쩍할인</ContainerHeader>
       <div className="content">
         <div className="images-container">
-          <div className="image-container">
-            <img
-              id="1"
-              src="http://thumbnail10.coupangcdn.com/thumbnails/remote/230x230ex/image/retail/images/432437954992902-8c4ac85e-1400-4da1-8d45-62bda8b9bd79.jpg"
-            />
-          </div>
-          <div className="image-container">
-            <img
-              id="2"
-              src="http://thumbnail10.coupangcdn.com/thumbnails/remote/230x230ex/image/retail/images/432437954992902-8c4ac85e-1400-4da1-8d45-62bda8b9bd79.jpg"
-            />
-          </div>
-          <div className="image-container">
-            <img
-              id="2"
-              src="http://thumbnail10.coupangcdn.com/thumbnails/remote/230x230ex/image/retail/images/432437954992902-8c4ac85e-1400-4da1-8d45-62bda8b9bd79.jpg"
-            />
-          </div>
-          <div className="image-container">
-            <img
-              id="2"
-              src="http://thumbnail10.coupangcdn.com/thumbnails/remote/230x230ex/image/retail/images/432437954992902-8c4ac85e-1400-4da1-8d45-62bda8b9bd79.jpg"
-            />
-          </div>
+          {products.map((item: ProductType, idx) => {
+            return (
+              <S.ImageContainer ref={imageRefs[idx]}>
+                <img id={`${idx}`} src={item.imgUrl} onClick={onTabClickHandler} />
+              </S.ImageContainer>
+            );
+          })}
         </div>
-        <ProductCard setSelect={setSelect} item={item} className="sale"></ProductCard>
+        <ProductCard
+          setSelect={setSelect}
+          item={products[currentTab]}
+          className="sale"
+        ></ProductCard>
       </div>
     </S.TabViewContainer>
   );

--- a/client/src/components/templates/TabViewContainer/TabViewContainer.tsx
+++ b/client/src/components/templates/TabViewContainer/TabViewContainer.tsx
@@ -23,7 +23,7 @@ export const TabViewContainer: React.FC<Props> = ({ products, setSelect }) => {
   }, []);
 
   const onTabClickHandler = (event: MouseEvent) => {
-    const target = (event.target as any).id;
+    const target = parseInt((event.target as HTMLImageElement).id, 10);
     resetCurrentTab(target);
     setCurrentTab(target);
   };

--- a/client/src/components/templates/TabViewContainer/styled.tsx
+++ b/client/src/components/templates/TabViewContainer/styled.tsx
@@ -9,15 +9,21 @@ export const TabViewContainer = styled.div`
   & .images-container {
     display: flex;
     justify-content: space-between;
-    & .image-container {
-      margin-right: 1%;
-      &:last-child {
-        margin-right: 0;
-      }
-    }
     & img {
+      box-sizing: border-box;
       width: 100%;
+      border: 2px solid transparent;
       height: auto;
     }
+    & .current-tab img {
+      border-color: red;
+    }
+  }
+`;
+
+export const ImageContainer = styled.div`
+  margin-right: 1%;
+  &:last-child {
+    margin-right: 0;
   }
 `;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -23,8 +23,8 @@ export type ProductType = {
   imgUrl: string;
 };
 
-type ProductArrType = {
-  products: Array<ProductType>;
+type LatestProductArrType = {
+  latestProducts: Array<ProductType>;
 };
 
 type CategoryArrType = {
@@ -33,7 +33,7 @@ type CategoryArrType = {
 
 type Props = {
   categories: Array<CategoryType>;
-  products: Array<ProductType>;
+  latestProducts: Array<ProductType>;
 };
 
 const MainPage: NextPage<Props> = (props) => {
@@ -50,7 +50,7 @@ const MainPage: NextPage<Props> = (props) => {
     <Layout title="연습용">
       <Banner />
       <CategoryContainer earliest={24} latest={50} categories={props.categories} />
-      <SlidableContainer products={props.products} setSelect={setSelect} />
+      <SlidableContainer products={props.latestProducts} setSelect={setSelect} />
       <TabViewContainer setSelect={setSelect} />
       <ToastModal select={select} setSelect={setSelect} />
     </Layout>
@@ -63,7 +63,7 @@ MainPage.getInitialProps = async () => {
   return { ...slidalbeResponse, ...categoryResponse };
 };
 
-const slidableContainerFetch = async (): Promise<ProductArrType> => {
+const slidableContainerFetch = async (): Promise<LatestProductArrType> => {
   let latestProducts = (await API.get(`/product/latest/${LatestProductsLimit}`)).data;
 
   console.info(latestProducts.message);
@@ -72,10 +72,10 @@ const slidableContainerFetch = async (): Promise<ProductArrType> => {
     latestProducts.status === HttpStatus.NOT_MODIFIED
   ) {
     const products = [...latestProducts.result];
-    return { products };
+    return { latestProducts: products };
   } else {
     console.error(`not defined status code: ${status}`);
-    return { products: [] };
+    return { latestProducts: [] };
   }
 };
 

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -3,7 +3,7 @@ import { NextPage } from 'next';
 import Layout from '@components/templates/Layout';
 import Banner from '@components/modules/Banner';
 import CategoryContainer, { CategoryType } from '@components/templates/CategoryContainer';
-import SlidableContainer, { ProductType } from '@components/templates/SlidableContainer';
+import SlidableContainer from '@components/templates/SlidableContainer';
 import ToastModal from '@components/modules/ToastModal';
 import TabViewContainer from '@components/templates/TabViewContainer';
 import API from '@utils/API';
@@ -11,6 +11,17 @@ import HttpStatus from 'http-status';
 import { LatestProductsLimit, OrderedCategoriesLimit } from '@utils/constants';
 import * as Images from '@assets/images';
 import { capitalize } from '@utils/helper';
+
+export type ProductType = {
+  id: number;
+  name: string;
+  price: number;
+  content: string;
+  discount: number;
+  outOfStockAt: Date | null;
+  subCategoryId: number;
+  imgUrl: string;
+};
 
 type ProductArrType = {
   products: Array<ProductType>;

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -90,7 +90,7 @@ const slidableContainerFetch = async (): Promise<LatestProductArrType> => {
 };
 
 const tabViewContainerFetch = async (): Promise<HighestOffProductArrType> => {
-  let highestOffProducts = (await API.get(`/product/latest/${HighestOffProductsLimit}`)).data;
+  let highestOffProducts = (await API.get(`/product/highest-off/${HighestOffProductsLimit}`)).data;
 
   console.info(highestOffProducts.message);
   if (

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -8,7 +8,11 @@ import ToastModal from '@components/modules/ToastModal';
 import TabViewContainer from '@components/templates/TabViewContainer';
 import API from '@utils/API';
 import HttpStatus from 'http-status';
-import { LatestProductsLimit, OrderedCategoriesLimit } from '@utils/constants';
+import {
+  LatestProductsLimit,
+  HighestOffProductsLimit,
+  OrderedCategoriesLimit,
+} from '@utils/constants';
 import * as Images from '@assets/images';
 import { capitalize } from '@utils/helper';
 
@@ -27,6 +31,10 @@ type LatestProductArrType = {
   latestProducts: Array<ProductType>;
 };
 
+type HighestOffProductArrType = {
+  highestOffProducts: Array<ProductType>;
+};
+
 type CategoryArrType = {
   categories: Array<CategoryType>;
 };
@@ -34,6 +42,7 @@ type CategoryArrType = {
 type Props = {
   categories: Array<CategoryType>;
   latestProducts: Array<ProductType>;
+  highestOffProducts: Array<ProductType>;
 };
 
 const MainPage: NextPage<Props> = (props) => {
@@ -51,7 +60,7 @@ const MainPage: NextPage<Props> = (props) => {
       <Banner />
       <CategoryContainer earliest={24} latest={50} categories={props.categories} />
       <SlidableContainer products={props.latestProducts} setSelect={setSelect} />
-      <TabViewContainer setSelect={setSelect} />
+      <TabViewContainer products={props.highestOffProducts} setSelect={setSelect} />
       <ToastModal select={select} setSelect={setSelect} />
     </Layout>
   );
@@ -59,8 +68,9 @@ const MainPage: NextPage<Props> = (props) => {
 
 MainPage.getInitialProps = async () => {
   const slidalbeResponse = await slidableContainerFetch();
+  const tabViewResponse = await tabViewContainerFetch();
   const categoryResponse = await categoryContainerFetch();
-  return { ...slidalbeResponse, ...categoryResponse };
+  return { ...slidalbeResponse, ...tabViewResponse, ...categoryResponse };
 };
 
 const slidableContainerFetch = async (): Promise<LatestProductArrType> => {
@@ -76,6 +86,22 @@ const slidableContainerFetch = async (): Promise<LatestProductArrType> => {
   } else {
     console.error(`not defined status code: ${status}`);
     return { latestProducts: [] };
+  }
+};
+
+const tabViewContainerFetch = async (): Promise<HighestOffProductArrType> => {
+  let highestOffProducts = (await API.get(`/product/latest/${HighestOffProductsLimit}`)).data;
+
+  console.info(highestOffProducts.message);
+  if (
+    highestOffProducts.status === HttpStatus.OK ||
+    highestOffProducts.status === HttpStatus.NOT_MODIFIED
+  ) {
+    const products = [...highestOffProducts.result];
+    return { highestOffProducts: products };
+  } else {
+    console.error(`not defined status code: ${status}`);
+    return { highestOffProducts: [] };
   }
 };
 

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -64,17 +64,14 @@ MainPage.getInitialProps = async () => {
 };
 
 const slidableContainerFetch = async (): Promise<ProductArrType> => {
-  let lastestProducts = (await API.get(`/product/latest/${LatestProductsLimit}`)).data;
+  let latestProducts = (await API.get(`/product/latest/${LatestProductsLimit}`)).data;
 
-  console.info(lastestProducts.message);
+  console.info(latestProducts.message);
   if (
-    lastestProducts.status === HttpStatus.OK ||
-    lastestProducts.status === HttpStatus.NOT_MODIFIED
+    latestProducts.status === HttpStatus.OK ||
+    latestProducts.status === HttpStatus.NOT_MODIFIED
   ) {
-    const products = [...lastestProducts.result];
-    return {
-      products: products,
-    };
+    const products = [...latestProducts.result];
   } else {
     console.error(`not defined status code: ${status}`);
     return { products: [] };

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -72,6 +72,7 @@ const slidableContainerFetch = async (): Promise<ProductArrType> => {
     latestProducts.status === HttpStatus.NOT_MODIFIED
   ) {
     const products = [...latestProducts.result];
+    return { products };
   } else {
     console.error(`not defined status code: ${status}`);
     return { products: [] };
@@ -86,7 +87,7 @@ const categoryContainerFetch = async (): Promise<CategoryArrType> => {
       category.url = Images[`Main${capitalize(category.name)}`];
       return category;
     });
-    return { categories: categories };
+    return { categories };
   } else {
     console.error(`not defined status code: ${status}`);
     return { categories: [] };

--- a/client/src/utils/constants.tsx
+++ b/client/src/utils/constants.tsx
@@ -59,4 +59,6 @@ export const baseURL = 'http://localhost:3000/api';
 
 export const LatestProductsLimit = 9;
 
+export const HighestOffProductsLimit = 4;
+
 export const OrderedCategoriesLimit = 9;

--- a/client/src/utils/constants.tsx
+++ b/client/src/utils/constants.tsx
@@ -55,7 +55,7 @@ export const ProductCountryOfOriginDesc = () => {
 };
 
 //dotenv로 관리 필요
-export const baseURL = 'http://localhost:4000/api';
+export const baseURL = 'http://localhost:3000/api';
 
 export const LatestProductsLimit = 9;
 

--- a/client/src/utils/constants.tsx
+++ b/client/src/utils/constants.tsx
@@ -62,3 +62,5 @@ export const LatestProductsLimit = 9;
 export const HighestOffProductsLimit = 4;
 
 export const OrderedCategoriesLimit = 9;
+
+export const TabViewProductsCount = 4;

--- a/server/src/controllers/product-controller.ts
+++ b/server/src/controllers/product-controller.ts
@@ -43,6 +43,41 @@ const findLatest = async (req: Request, res: Response, next: NextFunction) => {
   }
 };
 
+const findHighestOff = async (req: Request, res: Response, next: NextFunction) => {
+  const { params } = req;
+  const paramLimit = parseInt(params.limit);
+
+  try {
+    const products = await Product.findAll({
+      attributes: [
+        'id',
+        'name',
+        'price',
+        'content',
+        'discount',
+        'imgUrl',
+        'subCategoryId',
+        'outOfStockAt',
+      ],
+      where: {
+        deletedAt: {
+          [Op.is]: null,
+        },
+      },
+      limit: paramLimit,
+      order: [
+        ['discount', 'DESC'],
+        ['outOfStockAt', 'ASC'],
+      ],
+    });
+    res
+      .status(HttpStatus.OK)
+      .json(JsonResponse(HttpStatus.OK, `find product list with limit: ${paramLimit}`, products));
+  } catch (err) {
+    next(err);
+  }
+};
+
 const findById = async (req: Request, res: Response, next: NextFunction) => {
   const { params } = req;
   const paramId = parseInt(params.id);
@@ -200,6 +235,7 @@ const bulkCreate = async (req: Request, res: Response, next: NextFunction) => {
 
 export default {
   findLatest,
+  findHighestOff,
   findById,
   findBySubCategoryId,
   create,

--- a/server/src/routers/product-router.ts
+++ b/server/src/routers/product-router.ts
@@ -9,6 +9,7 @@ router.put('/:id', ProductController.update);
 router.delete('/:id', ProductController.softDelete);
 router.patch('/out/:id', ProductController.setOutOfStock);
 router.get('/latest/:limit', ProductController.findLatest);
+router.get('/highest-off/:limit', ProductController.findHighestOff);
 router.get('/sub/:subCategoryId/:limit', ProductController.findBySubCategoryId);
 router.post('/bulkcreate', ProductController.bulkCreate);
 


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

TabViewContainer의 목 데이터를 지우고, API를 만들어 데이터를 반영하고, useRef, useEffect 등을 활용하여 currentTab 표시 기능을 완성하였습니다.
- 할인율 순으로 상품을 가져올 수 있는 `findHighestOff` API 구현
- `pages/index` 에서 products를 latestProducts, highestOffProducts 등으로 분리
- 클릭 이벤트에 따라 TabViewContainer의 view 변경

## 체크리스트

### 리뷰어 1 - 김명성

- [x] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

### 리뷰어 2 - 이종구

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #106 

## 기타(스크린샷 등)

> PR에 대한 이해를 돕기 위한 자료가 있다면 추가합니다.

![image](https://user-images.githubusercontent.com/48426991/90726304-76bdaf00-e2fc-11ea-9567-5323e9e5fb7e.png)
