### PR TITLE
fix: Next 데이터 패치함수 수정

### DIFF
--- a/client/src/pages/cart/index.tsx
+++ b/client/src/pages/cart/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NextPage } from 'next';
+import { NextPage, GetServerSideProps } from 'next';
 import HttpStatus from 'http-status';
 import Layout, { LayoutProps } from '@commons/Layout';
 import { IconType, HeaderMainType, userId } from '@utils/constants';
@@ -29,7 +29,7 @@ const CartPage: NextPage<Props> = (props) => {
   );
 };
 
-CartPage.getInitialProps = async () => {
+export const getServerSideProps: GetServerSideProps = async () => {
   const { status, message, result } = (await API.get(`/cart/user/${userId}`)).data;
   console.info(message);
   if (status === HttpStatus.OK || status === HttpStatus.NOT_MODIFIED) {
@@ -57,9 +57,9 @@ CartPage.getInitialProps = async () => {
           imgUrl: item.product.imgUrl,
         };
       });
-    return { products, soldOutProducts };
+    return { props: { products, soldOutProducts } };
   } else {
-    return { products: [], soldOutProducts: [] };
+    return { props: { products: [], soldOutProducts: [] } };
   }
 };
 

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext } from 'react';
-import { NextPage } from 'next';
+import { NextPage, GetStaticProps } from 'next';
 import Layout, { LayoutProps } from '@commons/Layout';
 import Banner from '@components/modules/Banner';
 import CategoryContainer, { CategoryType } from '@components/templates/CategoryContainer';
@@ -75,11 +75,11 @@ const MainPage: NextPage<Props> = (props) => {
   );
 };
 
-MainPage.getInitialProps = async () => {
+export const getStaticProps: GetStaticProps = async () => {
   const slidalbeResponse = await slidableContainerFetch();
   const tabViewResponse = await tabViewContainerFetch();
   const categoryResponse = await categoryContainerFetch();
-  return { ...slidalbeResponse, ...tabViewResponse, ...categoryResponse };
+  return { props: { ...slidalbeResponse, ...tabViewResponse, ...categoryResponse } };
 };
 
 const slidableContainerFetch = async (): Promise<LatestProductArrType> => {


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.
Next 9.3 부터 getInitialProps 보다는 getStaticProps, getStaticPaths, getServerSideProps를 사용해서 fetch를 처리하는것을 권장하고 있다.

## 체크리스트

### 리뷰어 1 - 이종구

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #122 

## 참고자료

> 해당 PR과 관련된 자료가 있다면 추가합니다.

• getInitialProps의 경우 클라이언트와 서버 모두에서 실행됨. <- 권장 안함

• getStaticProps (SSG): 빌드할 때 데이터를 fetch함. 따라서 빌드시 고정되는 값이고, 빌드된 이후에는 변경이 불가능함. 정적페이지 생서을 지원한다. 유저 요청에 따라 매번 fetching할 필요가 없을 경우와 유저 특징적이지 않은 (누구나 볼 수 있는 게시물 같은 경우) 데이터를 불러올 때 사용한다.

• getStaticPaths (SSG): getStaticProps와 동일하지만, 동적라우팅에 따라 가변적으로 반응할 수 있는 속성. dynamic routes (예: /pages/titles/[id].tsx)가 적용된 페이지에 데이터(id)를 제공. 제공된 데이터마다 페이지가 생성됨. getStaticPaths에서 params를 적어줘야 하며, Props로 전달할 것은 getStaticProps를 이용

• getServerSideProps (SSR): 무조건 서버를 통해 데이터를 fetch함. 매요청당 실행됨. getInitialProps 처럼 사용. getStaticProps와 getServerSideProps의 차이는 빌드이후에도 data 변경가능 여부


🔗 [링크](url)

## 기타(스크린샷 등)

> PR에 대한 이해를 돕기 위한 자료가 있다면 추가합니다.
