### PR TITLE
feat: Banner 기능 업데이트 #125

### DIFF
--- a/client/src/components/modules/Banner/Banner.tsx
+++ b/client/src/components/modules/Banner/Banner.tsx
@@ -11,10 +11,12 @@ export const Banner = () => {
   const bannerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentsRef = useRef<Array<HTMLDivElement>>([]);
+  const indicatorsRef = useRef<Array<HTMLDivElement>>([]);
 
   const banner = bannerRef.current as HTMLDivElement;
   const container = containerRef.current as HTMLDivElement;
   const contents = contentsRef.current as HTMLDivElement[];
+  const indicators = indicatorsRef.current as HTMLDivElement[];
 
   useEffect(() => {
     addTouchEvent();
@@ -51,7 +53,12 @@ export const Banner = () => {
     });
   };
 
-  useEffect(() => {}, [currentSlide]);
+  useEffect(() => {
+    indicators.forEach((indicator) => {
+      indicator.classList.remove('current');
+    });
+    indicators[currentSlide].classList.add('current');
+  }, [currentSlide]);
 
   useInterval(
     () => {
@@ -79,7 +86,15 @@ export const Banner = () => {
           </S.SlideContent>
         ))}
       </S.SlideList>
-      <div></div>
+      <S.IndicatorContainer>
+        {Array.from({ length: MainBannerCount }, (_, idx) => (
+          <S.Indicator
+            ref={(el: HTMLDivElement) => {
+              indicatorsRef.current[idx] = el;
+            }}
+          />
+        ))}
+      </S.IndicatorContainer>
     </S.Banner>
   );
 };

--- a/client/src/components/modules/Banner/Banner.tsx
+++ b/client/src/components/modules/Banner/Banner.tsx
@@ -108,6 +108,7 @@ export const Banner = () => {
       <S.SlideList ref={containerRef} onScroll={scrollEventHandler}>
         {bannerList.map((banner, idx) => (
           <S.SlideContent
+            key={idx}
             className="slide_content"
             ref={(el: HTMLDivElement) => {
               contentsRef.current[idx] = el;
@@ -122,6 +123,7 @@ export const Banner = () => {
       <S.IndicatorContainer>
         {Array.from({ length: bannerList.length }, (_, idx) => (
           <S.Indicator
+            key={idx}
             ref={(el: HTMLDivElement) => {
               indicatorsRef.current[idx] = el;
             }}

--- a/client/src/components/modules/Banner/Banner.tsx
+++ b/client/src/components/modules/Banner/Banner.tsx
@@ -23,7 +23,8 @@ export const Banner = () => {
   const contents = contentsRef.current as HTMLDivElement[];
   const indicators = indicatorsRef.current as HTMLDivElement[];
 
-  const initBannerWidth = (container: HTMLDivElement) => {
+  const initBannerWidth = () => {
+    const container = containerRef.current as HTMLDivElement;
     container.style.scrollBehavior = 'initial';
     container.scrollLeft += innerWidth;
   };
@@ -31,12 +32,6 @@ export const Banner = () => {
   const removeUselessIndicators = () => {
     indicators[0].remove();
     indicators[length + 1].remove();
-  };
-
-  const addEventHandlers = (container: HTMLDivElement) => {
-    container.addEventListener('scroll', () => {
-      addScrollEventHandler(container);
-    });
   };
 
   const createIntersectionObserver = () => {
@@ -69,7 +64,8 @@ export const Banner = () => {
     });
   };
 
-  const addScrollEventHandler = (container: HTMLDivElement) => {
+  const scrollEventHandler = () => {
+    const container = containerRef.current as HTMLDivElement;
     const { scrollWidth, scrollLeft } = container;
 
     if (scrollWidth - innerWidth - scrollLeft <= 0) {
@@ -86,10 +82,7 @@ export const Banner = () => {
 
   // Initial Setting
   useEffect(() => {
-    const container = containerRef.current as HTMLDivElement;
-
-    addEventHandlers(container);
-    initBannerWidth(container);
+    initBannerWidth();
     removeUselessIndicators();
     createIntersectionObserver();
   }, []);
@@ -112,7 +105,7 @@ export const Banner = () => {
 
   return (
     <S.Banner ref={BannerRef}>
-      <S.SlideList ref={containerRef}>
+      <S.SlideList ref={containerRef} onScroll={scrollEventHandler}>
         {bannerList.map((banner, idx) => (
           <S.SlideContent
             className="slide_content"

--- a/client/src/components/modules/Banner/Banner.tsx
+++ b/client/src/components/modules/Banner/Banner.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect, useRef } from 'react';
+import * as S from './styled';
+
+const smallBannerList = [
+  { src: `./assets/images/banners/small/banner-small-1.jpg`, href: '#' },
+  { src: `./assets/images/banners/small/banner-small-2.jpg`, href: '#' },
+  { src: `./assets/images/banners/small/banner-small-3.jpg`, href: '#' },
+  { src: `./assets/images/banners/small/banner-small-4.jpg`, href: '#' },
+  { src: `./assets/images/banners/small/banner-small-5.jpg`, href: '#' },
+];
+
+const length = smallBannerList.length;
+
+export const Banner = () => {
+  const [currentSlide, setCurrentSlide] = useState(1);
+
+  const BannerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentsRef = useRef<Array<HTMLDivElement>>([]);
+  const indicatorsRef = useRef<Array<HTMLDivElement>>([]);
+
+  const Banner = BannerRef.current as HTMLDivElement;
+  const contents = contentsRef.current as HTMLDivElement[];
+  const indicators = indicatorsRef.current as HTMLDivElement[];
+
+  const initBannerWidth = (container: HTMLDivElement) => {
+    container.style.scrollBehavior = 'initial';
+    container.scrollLeft += innerWidth;
+  };
+
+  const removeUselessIndicators = () => {
+    indicators[0].remove();
+    indicators[length + 1].remove();
+  };
+
+  const addEventHandlers = (container: HTMLDivElement) => {
+    container.addEventListener('scroll', () => {
+      addScrollEventHandler(container);
+    });
+  };
+
+  const createIntersectionObserver = () => {
+    const BannerObserveHandler = (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (!entry.isIntersecting) {
+          return;
+        }
+        if (contents.indexOf(entry.target as HTMLDivElement) === length + 1) {
+          setCurrentSlide(1);
+          return;
+        }
+        if (contents.indexOf(entry.target as HTMLDivElement) === 0) {
+          setCurrentSlide(length);
+          return;
+        }
+        setCurrentSlide(() => contents.indexOf(entry.target as HTMLDivElement));
+      });
+    };
+
+    const options = {
+      root: Banner,
+      threshold: 0.9,
+    };
+
+    const observer = new IntersectionObserver(BannerObserveHandler, options);
+
+    contents.forEach((content) => {
+      observer.observe(content);
+    });
+  };
+
+  const addScrollEventHandler = (container: HTMLDivElement) => {
+    const { scrollWidth, scrollLeft } = container;
+
+    if (scrollWidth - innerWidth - scrollLeft <= 0) {
+      container.style.scrollBehavior = 'initial';
+      container.scrollLeft = innerWidth;
+      container.style.scrollBehavior = 'smooth';
+    }
+    if (scrollLeft <= 0) {
+      container.style.scrollBehavior = 'initial';
+      container.scrollLeft = scrollWidth - 2 * innerWidth;
+      container.style.scrollBehavior = 'smooth';
+    }
+  };
+
+  // Initial Setting
+  useEffect(() => {
+    const container = containerRef.current as HTMLDivElement;
+
+    addEventHandlers(container);
+    initBannerWidth(container);
+    removeUselessIndicators();
+    createIntersectionObserver();
+  }, []);
+
+  // Set Indicator
+  useEffect(() => {
+    if (currentSlide === 0) return;
+    if (currentSlide === length + 1) return;
+
+    indicators.forEach((indicator) => {
+      indicator.classList.remove('current');
+    });
+    indicators[currentSlide].classList.add('current');
+  }, [currentSlide]);
+
+  const bannerList =
+    length > 1
+      ? [smallBannerList[length - 1], ...smallBannerList, smallBannerList[0]]
+      : smallBannerList;
+
+  return (
+    <S.Banner ref={BannerRef}>
+      <S.SlideList ref={containerRef}>
+        {bannerList.map((banner, idx) => (
+          <S.SlideContent
+            className="slide_content"
+            ref={(el: HTMLDivElement) => {
+              contentsRef.current[idx] = el;
+            }}
+          >
+            <a href={banner.href}>
+              <img className="banner-image" src={banner.src} />
+            </a>
+          </S.SlideContent>
+        ))}
+      </S.SlideList>
+      <S.IndicatorContainer>
+        {Array.from({ length: bannerList.length }, (_, idx) => (
+          <S.Indicator
+            ref={(el: HTMLDivElement) => {
+              indicatorsRef.current[idx] = el;
+            }}
+          />
+        ))}
+      </S.IndicatorContainer>
+    </S.Banner>
+  );
+};

--- a/client/src/components/modules/Banner/index.tsx
+++ b/client/src/components/modules/Banner/index.tsx
@@ -1,0 +1,3 @@
+import { Banner } from './Banner';
+
+export default Banner;

--- a/client/src/components/modules/Banner/index.tsx
+++ b/client/src/components/modules/Banner/index.tsx
@@ -1,3 +1,0 @@
-import { Banner } from './Banner';
-
-export default Banner;

--- a/client/src/components/modules/Banner/styled.tsx
+++ b/client/src/components/modules/Banner/styled.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 export const Banner = styled.div`
-  display: flex;
   margin: auto;
 
   overflow: hidden;
@@ -33,5 +32,33 @@ export const SlideContent = styled.div`
   & .banner-image {
     width: 100%;
     height: auto;
+  }
+`;
+
+export const IndicatorContainer = styled.div`
+  position: absolute;
+  bottom: 2rem;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Indicator = styled.div`
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-right: 2.5rem;
+  border-radius: 10rem;
+  background-color: rgba(255, 255, 255, 0.4);
+  transition: background-color 300ms;
+
+  &.current {
+    background-color: #ffffff;
+    box-shadow: 0 0 0 1px #ffffff;
+  }
+
+  &:last-child {
+    margin-right: 0;
   }
 `;

--- a/client/src/components/modules/Banner/styled.tsx
+++ b/client/src/components/modules/Banner/styled.tsx
@@ -1,14 +1,17 @@
 import styled from 'styled-components';
 
 export const Banner = styled.div`
-  position: relative;
-  width: 100%;
+  display: flex;
   margin: auto;
+
+  overflow: hidden;
+  position: relative;
 `;
 
-export const SlideBox = styled.div`
-  width: 100%;
-  margin: auto;
+export const SlideList = styled.div`
+  display: flex;
+  transition: 300ms;
+
   overflow-x: scroll;
   -webkit-scroll-snap-type: x mandatory;
   -ms-scroll-snap-type: x mandatory;
@@ -16,22 +19,19 @@ export const SlideBox = styled.div`
   scroll-behavior: smooth;
   -ms-overflow-style: none;
   scrollbar-width: none;
+
   &::-webkit-scrollbar {
     display: none;
   }
 `;
 
-export const SlideList = styled.div`
-  display: flex;
-  transition: 300ms;
+export const SlideContent = styled.div`
+  min-width: 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
 
-  & .slide_content {
-    min-width: 100%;
-    scroll-snap-align: start;
-    scroll-snap-stop: always;
-    & .banner-image {
-      width: 100%;
-      height: auto;
-    }
+  & .banner-image {
+    width: 100%;
+    height: auto;
   }
 `;

--- a/client/src/components/modules/Banner/styled.tsx
+++ b/client/src/components/modules/Banner/styled.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+
+export const Banner = styled.div`
+  margin: auto;
+
+  overflow: hidden;
+  position: relative;
+`;
+
+export const SlideList = styled.div`
+  display: flex;
+  transition: 300ms;
+
+  overflow-x: scroll;
+  -webkit-scroll-snap-type: x mandatory;
+  -ms-scroll-snap-type: x mandatory;
+  scroll-snap-type: x mandatory;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+export const SlideContent = styled.div`
+  min-width: 100%;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+
+  & .banner-image {
+    width: 100%;
+    height: auto;
+  }
+`;
+
+export const IndicatorContainer = styled.div`
+  position: absolute;
+  bottom: 2rem;
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Indicator = styled.div`
+  width: 1.1rem;
+  height: 1.1rem;
+  margin-right: 2.5rem;
+  border-radius: 10rem;
+  background-color: rgba(255, 255, 255, 0.4);
+  transition: background-color 300ms;
+
+  &.current {
+    background-color: #ffffff;
+    box-shadow: 0 0 0 1px #ffffff;
+  }
+
+  &:last-child {
+    margin-right: 0;
+  }
+`;

--- a/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
+++ b/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
@@ -26,7 +26,9 @@ export const CarouselBanner = () => {
   const contents = contentsRef.current as HTMLDivElement[];
   const indicators = indicatorsRef.current as HTMLDivElement[];
 
-  const initBannerWidth = (container: HTMLDivElement) => {
+  const initBannerWidth = () => {
+    const container = containerRef.current as HTMLDivElement;
+
     container.style.scrollBehavior = 'initial';
     container.scrollLeft += innerWidth;
   };
@@ -34,18 +36,6 @@ export const CarouselBanner = () => {
   const removeUselessIndicators = () => {
     indicators[0].remove();
     indicators[length + 1].remove();
-  };
-
-  const addEventHandlers = (container: HTMLDivElement) => {
-    container.addEventListener('touchstart', () => {
-      setIsRunning(false);
-    });
-    container.addEventListener('touchend', () => {
-      setIsRunning(true);
-    });
-    container.addEventListener('scroll', () => {
-      addScrollEventHandler(container);
-    });
   };
 
   const createIntersectionObserver = () => {
@@ -78,7 +68,8 @@ export const CarouselBanner = () => {
     });
   };
 
-  const addScrollEventHandler = (container: HTMLDivElement) => {
+  const scrollEventHandler = () => {
+    const container = containerRef.current as HTMLDivElement;
     const { scrollWidth, scrollLeft } = container;
 
     if (scrollWidth - innerWidth - scrollLeft <= 0) {
@@ -95,10 +86,7 @@ export const CarouselBanner = () => {
 
   // Initial Setting
   useEffect(() => {
-    const container = containerRef.current as HTMLDivElement;
-
-    addEventHandlers(container);
-    initBannerWidth(container);
+    initBannerWidth();
     removeUselessIndicators();
     createIntersectionObserver();
   }, []);
@@ -130,7 +118,18 @@ export const CarouselBanner = () => {
 
   return (
     <S.CarouselBanner ref={carouselBannerRef}>
-      <S.SlideList ref={containerRef}>
+      <S.SlideList
+        ref={containerRef}
+        onTouchStart={() => {
+          setIsRunning(false);
+        }}
+        onTouchEnd={() => {
+          setIsRunning(true);
+        }}
+        onScroll={() => {
+          scrollEventHandler();
+        }}
+      >
         {bannerList.map((banner, idx) => (
           <S.SlideContent
             className="slide_content"

--- a/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
+++ b/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
@@ -132,6 +132,7 @@ export const CarouselBanner = () => {
       >
         {bannerList.map((banner, idx) => (
           <S.SlideContent
+            key={idx}
             className="slide_content"
             ref={(el: HTMLDivElement) => {
               contentsRef.current[idx] = el;
@@ -146,6 +147,7 @@ export const CarouselBanner = () => {
       <S.IndicatorContainer>
         {Array.from({ length: bannerList.length }, (_, idx) => (
           <S.Indicator
+            key={idx}
             ref={(el: HTMLDivElement) => {
               indicatorsRef.current[idx] = el;
             }}

--- a/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
+++ b/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
@@ -126,9 +126,7 @@ export const CarouselBanner = () => {
         onTouchEnd={() => {
           setIsRunning(true);
         }}
-        onScroll={() => {
-          scrollEventHandler();
-        }}
+        onScroll={scrollEventHandler}
       >
         {bannerList.map((banner, idx) => (
           <S.SlideContent

--- a/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
+++ b/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
@@ -1,19 +1,19 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useInterval } from '@utils/customHooks';
 import * as S from './styled';
-import { MainBannerCount } from '@utils/constants';
+import { CarouselBannerCount } from '@utils/constants';
 
-export const Banner = () => {
+export const CarouselBanner = () => {
   const delay = 3000;
   const [isRunning, setIsRunning] = useState(true);
   const [currentSlide, setCurrentSlide] = useState(1);
 
-  const bannerRef = useRef<HTMLDivElement>(null);
+  const carouselBannerRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const contentsRef = useRef<Array<HTMLDivElement>>([]);
   const indicatorsRef = useRef<Array<HTMLDivElement>>([]);
 
-  const banner = bannerRef.current as HTMLDivElement;
+  const carouselBanner = carouselBannerRef.current as HTMLDivElement;
   const container = containerRef.current as HTMLDivElement;
   const contents = contentsRef.current as HTMLDivElement[];
   const indicators = indicatorsRef.current as HTMLDivElement[];
@@ -33,7 +33,7 @@ export const Banner = () => {
   };
 
   const createIntersectionObserver = () => {
-    const bannerObserveHandler = (entries: IntersectionObserverEntry[]) => {
+    const carouselBannerObserveHandler = (entries: IntersectionObserverEntry[]) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           setCurrentSlide(() => contents.indexOf(entry.target as HTMLDivElement));
@@ -42,11 +42,11 @@ export const Banner = () => {
     };
 
     const options = {
-      root: banner,
+      root: carouselBanner,
       threshold: 0.9,
     };
 
-    const observer = new IntersectionObserver(bannerObserveHandler, options);
+    const observer = new IntersectionObserver(carouselBannerObserveHandler, options);
 
     contents.forEach((content) => {
       observer.observe(content);
@@ -62,7 +62,7 @@ export const Banner = () => {
 
   useInterval(
     () => {
-      const containerWidth = MainBannerCount * innerWidth;
+      const containerWidth = CarouselBannerCount * innerWidth;
       container.style.scrollBehavior = 'smooth';
       container.scrollLeft = (container.scrollLeft + innerWidth) % containerWidth;
     },
@@ -70,9 +70,9 @@ export const Banner = () => {
   );
 
   return (
-    <S.Banner ref={bannerRef}>
+    <S.CarouselBanner ref={carouselBannerRef}>
       <S.SlideList ref={containerRef}>
-        {Array.from({ length: MainBannerCount }, (_, idx) => (
+        {Array.from({ length: CarouselBannerCount }, (_, idx) => (
           <S.SlideContent
             className="slide_content"
             ref={(el: HTMLDivElement) => {
@@ -80,14 +80,14 @@ export const Banner = () => {
             }}
           >
             <img
-              className="banner-image"
+              className="carousel-banner-image"
               src={`./assets/images/banners/big/banner-big-${idx + 1}.gif`}
             />
           </S.SlideContent>
         ))}
       </S.SlideList>
       <S.IndicatorContainer>
-        {Array.from({ length: MainBannerCount }, (_, idx) => (
+        {Array.from({ length: CarouselBannerCount }, (_, idx) => (
           <S.Indicator
             ref={(el: HTMLDivElement) => {
               indicatorsRef.current[idx] = el;
@@ -95,6 +95,6 @@ export const Banner = () => {
           />
         ))}
       </S.IndicatorContainer>
-    </S.Banner>
+    </S.CarouselBanner>
   );
 };

--- a/client/src/components/modules/CarouselBanner/index.tsx
+++ b/client/src/components/modules/CarouselBanner/index.tsx
@@ -1,0 +1,3 @@
+import { CarouselBanner } from './CarouselBanner';
+
+export default CarouselBanner;

--- a/client/src/components/modules/CarouselBanner/styled.tsx
+++ b/client/src/components/modules/CarouselBanner/styled.tsx
@@ -15,7 +15,6 @@ export const SlideList = styled.div`
   -webkit-scroll-snap-type: x mandatory;
   -ms-scroll-snap-type: x mandatory;
   scroll-snap-type: x mandatory;
-  scroll-behavior: smooth;
   -ms-overflow-style: none;
   scrollbar-width: none;
 

--- a/client/src/components/modules/CarouselBanner/styled.tsx
+++ b/client/src/components/modules/CarouselBanner/styled.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Banner = styled.div`
+export const CarouselBanner = styled.div`
   margin: auto;
 
   overflow: hidden;
@@ -29,7 +29,7 @@ export const SlideContent = styled.div`
   scroll-snap-align: start;
   scroll-snap-stop: always;
 
-  & .banner-image {
+  & .carousel-banner-image {
     width: 100%;
     height: auto;
   }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useContext } from 'react';
 import { NextPage, GetStaticProps } from 'next';
 import Layout, { LayoutProps } from '@commons/Layout';
 import CarouselBanner from '@components/modules/CarouselBanner';
+import Banner from '@components/modules/Banner';
 import CategoryContainer, { CategoryType } from '@components/templates/CategoryContainer';
 import SlidableContainer from '@components/templates/SlidableContainer';
 import ToastModal from '@components/modules/ToastModal';
@@ -70,6 +71,7 @@ const MainPage: NextPage<Props> = (props) => {
       <CategoryContainer earliest={24} latest={50} categories={props.categories} />
       <SlidableContainer products={props.latestProducts} />
       <TabViewContainer products={props.highestOffProducts} />
+      <Banner />
       <ToastModal />
     </Layout>
   );

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useContext } from 'react';
 import { NextPage, GetStaticProps } from 'next';
 import Layout, { LayoutProps } from '@commons/Layout';
-import Banner from '@components/modules/Banner';
+import CarouselBanner from '@components/modules/CarouselBanner';
 import CategoryContainer, { CategoryType } from '@components/templates/CategoryContainer';
 import SlidableContainer from '@components/templates/SlidableContainer';
 import ToastModal from '@components/modules/ToastModal';
@@ -66,7 +66,7 @@ const MainPage: NextPage<Props> = (props) => {
 
   return (
     <Layout title={layoutProps.title} headerProps={layoutProps.headerProps}>
-      <Banner />
+      <CarouselBanner />
       <CategoryContainer earliest={24} latest={50} categories={props.categories} />
       <SlidableContainer products={props.latestProducts} />
       <TabViewContainer products={props.highestOffProducts} />

--- a/client/src/utils/constants.tsx
+++ b/client/src/utils/constants.tsx
@@ -72,4 +72,4 @@ export const TabViewProductsCount = 4;
 
 export const userId = 1;
 
-export const MainBannerCount = 5;
+export const CarouselBannerCount = 5;


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

- Indicator 생성
- 자동으로 넘겨지는 CarouselBanner와 드래그만 가능한 Banner를 분리
- 무한 스크롤 구현
- bannerList를 변수로 분리
- translateX 방식을 scrollLeft를 조절하는 방식으로 변경
   - 현재 Safari에서 `scroll-behavior: smooth` 이 지원하지 않으므로 이후 polyfill를 적용하는 방법을 찾으면 가능할 것 같습니다.

## 체크리스트

### 리뷰어 1 - 이종구

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #125 

## 기타(스크린샷 등)

> PR에 대한 이해를 돕기 위한 자료가 있다면 추가합니다.

![image](https://user-images.githubusercontent.com/48426991/91042998-b31b4300-e64d-11ea-822e-3be7fe37aa5f.png)
