### PR TITLE
Fetchable container#164

### DIFF
--- a/client/src/components/atoms/Badge/styled.tsx
+++ b/client/src/components/atoms/Badge/styled.tsx
@@ -2,11 +2,13 @@ import styled from 'styled-components';
 
 export const Badge = styled.div`
   display: flex;
+  font-size: 2em;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 3rem;
-  height: 3rem;
+  width: 3em;
+  height: 3em;
+  font-weight: 500;
   background-color: red;
   color: #fff;
 `;

--- a/client/src/components/atoms/LinkBox/LinkBox.tsx
+++ b/client/src/components/atoms/LinkBox/LinkBox.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import * as S from './styled';
 import Link from 'next/link';
 import Icon from '@components/atoms/Icon';
+import { IconType } from '@utils/constants';
 
 type Props = {
   url: string;
   name: string;
-  icon?: string;
+  icon?: IconType;
 };
 
 export const LinkBox: React.FC<Props> = ({ url, name, icon }) => {

--- a/client/src/components/modules/ContainerHeader/styled.tsx
+++ b/client/src/components/modules/ContainerHeader/styled.tsx
@@ -7,4 +7,6 @@ export const ContainerHeader = styled.div`
   font-size: 2rem;
   font-weight: 600;
   margin: 1rem 1rem;
+  padding: 8px 0px;
+  color: black;
 `;

--- a/client/src/components/modules/ProductCard/ProductCard.tsx
+++ b/client/src/components/modules/ProductCard/ProductCard.tsx
@@ -96,7 +96,7 @@ export const ProductCard: React.FC<Props> = ({
                 </>
               )}
               <span className="price">{item.price.toLocaleString()}원</span>
-              {className === 'sale' && <Icon icon={'Basket'} size={1.5} />}
+              {className === 'sale' && <Icon icon={'Basket'} size={4} />}
             </S.ProductPriceRow>
           </div>
         </S.ProductInfo>

--- a/client/src/components/modules/ProductCard/ProductCard.tsx
+++ b/client/src/components/modules/ProductCard/ProductCard.tsx
@@ -26,6 +26,7 @@ export const ProductCard: React.FC<Props> = ({
   const setSelect = useContext(Context).setSelect;
   const token = getCookie('authorization');
   const router = useRouter();
+  const rawPrice = (item.price * (100 + item.discount)) / 100;
 
   useEffect(() => {
     if (likeProducts.length) {
@@ -82,11 +83,21 @@ export const ProductCard: React.FC<Props> = ({
             {Liked ? <Icon icon={'Heart'} size={3} /> : <Icon icon={'RegHeart'} size={3} />}
           </div>
         </div>
-        <S.ProductInfo>
+        <S.ProductInfo className={className}>
           <div className="item-name">{item.name}</div>
-          <div className="price-row">
-            <div className="item-price">{item.price}원</div>
-            {className === 'sale' && <Icon icon={'Basket'} size={1.5} />}
+          <div>
+            <S.ProductPriceRow>
+              {item.discount !== 0 && (
+                <>
+                  <span className="sale-rate">{item.discount}%</span>
+                  <span className="raw-price">
+                    {(Math.ceil(rawPrice / 100) * 100).toLocaleString()}원
+                  </span>
+                </>
+              )}
+              <span className="price">{item.price.toLocaleString()}원</span>
+              {className === 'sale' && <Icon icon={'Basket'} size={1.5} />}
+            </S.ProductPriceRow>
           </div>
         </S.ProductInfo>
       </S.ProductCard>

--- a/client/src/components/modules/ProductCard/styled.tsx
+++ b/client/src/components/modules/ProductCard/styled.tsx
@@ -27,6 +27,7 @@ export const ProductCard = styled.div`
   &.slide {
     width: 16rem;
     margin-right: 1rem;
+    margin-bottom: 2rem;
     &:first-child {
       margin-left: 1rem;
     }
@@ -37,6 +38,7 @@ export const ProductCard = styled.div`
 
   /* sale */
   &.sale {
+    margin-bottom: 3rem;
     & .image-container {
       overflow: hidden;
       width: 100%;
@@ -52,6 +54,16 @@ export const ProductCard = styled.div`
       transform: translate(0, -12.5%);
     }
   }
+
+  /* grid */
+  &.grid {
+    margin-bottom: 4rem;
+  }
+
+  /* main */
+  &.main {
+    margin-bottom: 4rem;
+  }
 `;
 
 export const ProductImg = styled.img`
@@ -61,26 +73,48 @@ export const ProductImg = styled.img`
 `;
 
 export const ProductInfo = styled.div`
-  margin-top: 1rem;
-  font-size: 2rem;
+  margin-top: 1em;
+  font-weight: 500;
+
+  &.slide {
+    font-size: 1.6rem;
+  }
+  &.sale {
+    font-size: 2rem;
+  }
+  &.grid {
+    font-size: 1.6rem;
+  }
+  &.main {
+    font-size: 1.9rem;
+  }
+
   & .item-name {
     overflow: hidden;
+    margin-bottom: 6px;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     text-overflow: ellipsis;
   }
+`;
 
-  & .price-row {
-    display: flex;
+export const ProductPriceRow = styled.div`
+  & .sale-rate {
+    font-size: 1em;
+    font-weight: 700;
+    color: red;
+    margin-right: 1rem;
   }
-
-  & .price-row i {
-    margin-left: auto;
+  & .raw-price {
+    font-size: 1em;
+    color: lightgray;
+    text-decoration: line-through;
+    margin-right: 1rem;
   }
-
-  & .item-price {
-    margin: 1rem 0;
-    font-weight: 600;
+  & .price {
+    font-size: 1.2em;
+    color: black;
+    font-weight: 700;
   }
 `;

--- a/client/src/components/modules/ProductCard/styled.tsx
+++ b/client/src/components/modules/ProductCard/styled.tsx
@@ -4,6 +4,7 @@ export const ProductCard = styled.div`
   /* common */
   display: flex;
   flex-direction: column;
+  color: black;
   cursor: pointer;
   & .image-container {
     position: relative;

--- a/client/src/components/modules/ProductCard/styled.tsx
+++ b/client/src/components/modules/ProductCard/styled.tsx
@@ -100,6 +100,7 @@ export const ProductInfo = styled.div`
 `;
 
 export const ProductPriceRow = styled.div`
+  position: relative;
   & .sale-rate {
     font-size: 1em;
     font-weight: 700;
@@ -116,5 +117,10 @@ export const ProductPriceRow = styled.div`
     font-size: 1.2em;
     color: black;
     font-weight: 700;
+  }
+  & i {
+    position: absolute;
+    top: -1rem;
+    right: 1.5rem;
   }
 `;

--- a/client/src/components/templates/CategoryContainer/CategoryContainer.tsx
+++ b/client/src/components/templates/CategoryContainer/CategoryContainer.tsx
@@ -43,7 +43,7 @@ export const CategoryContainer = (props: Props) => {
                 id={category.id}
                 name={category.name}
                 url={category.url}
-                onClick={() => router.replace(`/categories/${category.id}`)}
+                onClick={() => router.push(`/categories/${category.id}`)}
               />
             ))}
           {

--- a/client/src/components/templates/CategoryContainer/styled.tsx
+++ b/client/src/components/templates/CategoryContainer/styled.tsx
@@ -4,6 +4,9 @@ export const WrapperContainer = styled.div`
   display: flex;
   flex-direction: column;
   background-color: white;
+  margin-bottom: 10px;
+  color: rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 2px 5px;
 `;
 
 export const CategoryContainer = styled.div`

--- a/client/src/components/templates/FavoriteContainer/FavoriteContainer.tsx
+++ b/client/src/components/templates/FavoriteContainer/FavoriteContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useContext } from 'react';
 import * as S from './styled';
 import { Context } from '@commons/Context';
 import ProductCard from '@components/modules/ProductCard';

--- a/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
+++ b/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
@@ -31,7 +31,7 @@ export const FetchableContainer: React.FC<Props> = ({ title, products }) => {
                 item={item}
                 likeProducts={likeProducts}
                 setLikeProducts={setLikeProducts}
-                className={'main'}
+                className={'grid'}
               />
             );
           })}

--- a/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
+++ b/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
@@ -5,7 +5,6 @@ import ProductCard from '@components/modules/ProductCard';
 import { ProductType } from '@pages/index';
 import ContainerHeader from '@components/modules/ContainerHeader';
 import { Context } from '@commons/Context';
-import { IconType } from '@utils/constants';
 
 type ProductArrType = Array<ProductType>;
 
@@ -17,7 +16,7 @@ type Props = {
 export const FetchableContainer: React.FC<Props> = ({ title, products }) => {
   const { likeProducts, setLikeProducts } = useContext(Context);
   const totalSlides = Math.floor(products.length / 6);
-  const [currentSlide, setCurrentSlide] = useState(1);
+  const [currentSlide] = useState(1);
 
   return (
     <S.FetchableContainer>

--- a/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
+++ b/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
@@ -1,9 +1,51 @@
-import React from 'react';
+import React, { useState, useContext } from 'react';
 import * as S from './styled';
+import Icon from '@components/atoms/Icon';
+import ProductCard from '@components/modules/ProductCard';
+import { ProductType } from '@pages/index';
+import ContainerHeader from '@components/modules/ContainerHeader';
+import { Context } from '@commons/Context';
+import { IconType } from '@utils/constants';
 
-type Props = {};
+type ProductArrType = Array<ProductType>;
 
-export const FetchableContainer: React.FC<Props> = (props) => {
-  return <S.FetchableContainer />;
+type Props = {
+  title: string;
+  products: ProductArrType;
 };
 
+export const FetchableContainer: React.FC<Props> = ({ title, products }) => {
+  const { likeProducts, setLikeProducts } = useContext(Context);
+  const totalSlides = Math.floor(products.length / 6);
+  const [currentSlide, setCurrentSlide] = useState(1);
+
+  return (
+    <S.FetchableContainer>
+      <ContainerHeader>{title}</ContainerHeader>
+      <div className="wrapper">
+        <div className="content">
+          {products.map((item: ProductType, idx: number) => {
+            return (
+              <ProductCard
+                key={idx}
+                item={item}
+                likeProducts={likeProducts}
+                setLikeProducts={setLikeProducts}
+                className={'main'}
+              />
+            );
+          })}
+        </div>
+        <div className="fetch-button">
+          <Icon icon={IconType.REFRESH} size={2} />
+          <span className="title">{title}</span>
+          <span>다른 상품 보기 </span>
+          <span className="page-count">
+            <span className="current-count">{currentSlide}</span>/
+            <span className="total-count">{totalSlides}</span>
+          </span>
+        </div>
+      </div>
+    </S.FetchableContainer>
+  );
+};

--- a/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
+++ b/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
@@ -37,7 +37,7 @@ export const FetchableContainer: React.FC<Props> = ({ title, products }) => {
           })}
         </div>
         <div className="fetch-button">
-          <Icon icon={IconType.REFRESH} size={2} />
+          <Icon icon={'Refresh'} size={2} />
           <span className="title">{title}</span>
           <span>다른 상품 보기 </span>
           <span className="page-count">

--- a/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
+++ b/client/src/components/templates/FetchableContainer/FetchableContainer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import * as S from './styled';
+
+type Props = {};
+
+export const FetchableContainer: React.FC<Props> = (props) => {
+  return <S.FetchableContainer />;
+};
+

--- a/client/src/components/templates/FetchableContainer/index.tsx
+++ b/client/src/components/templates/FetchableContainer/index.tsx
@@ -1,0 +1,3 @@
+import { FetchableContainer } from './FetchableContainer';
+
+export default FetchableContainer;

--- a/client/src/components/templates/FetchableContainer/styled.tsx
+++ b/client/src/components/templates/FetchableContainer/styled.tsx
@@ -1,3 +1,45 @@
 import styled from 'styled-components';
 
-export const FetchableContainer = styled.div<{}>``
+export const FetchableContainer = styled.div<{}>`
+  width: 100%;
+  background-color: white;
+  margin-bottom: 10px;
+  color: rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 0px 5px;
+
+  & .wrapper {
+    padding: 0 1rem;
+  }
+  & .content {
+    display: grid;
+    align-items: center;
+    grid-template-columns: 1fr 1fr 1fr;
+    justify-content: center;
+    align-items: flex-start;
+    column-gap: 1rem;
+  }
+  & .fetch-button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 2rem;
+    border-top: 1.5px solid #efefef;
+    padding: 2rem;
+    margin-top: 15px;
+    color: black;
+
+    & > * {
+      margin-right: 6px;
+    }
+    & i {
+      transform: translate(0%, -10%);
+      color: #2cc0bd;
+    }
+    & .title {
+      color: #2cc0bd;
+    }
+    & .page-count {
+      margin-right: 0;
+    }
+  }
+`;

--- a/client/src/components/templates/FetchableContainer/styled.tsx
+++ b/client/src/components/templates/FetchableContainer/styled.tsx
@@ -24,8 +24,7 @@ export const FetchableContainer = styled.div<{}>`
     align-items: center;
     font-size: 2rem;
     border-top: 1.5px solid #efefef;
-    padding: 2rem;
-    margin-top: 15px;
+    padding: 16px;
     color: black;
 
     & > * {

--- a/client/src/components/templates/FetchableContainer/styled.tsx
+++ b/client/src/components/templates/FetchableContainer/styled.tsx
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const FetchableContainer = styled.div<{}>``

--- a/client/src/components/templates/ProductsByCategoryContainer/ProductsByCategoryContainer.tsx
+++ b/client/src/components/templates/ProductsByCategoryContainer/ProductsByCategoryContainer.tsx
@@ -30,7 +30,7 @@ export const ProductsByCategoryContainer: React.FC<Props> = ({
       {headerType === 'main' && (
         <ContainerHeader
           moreBtn
-          onMoreBtnClickHandler={() => router.replace(`/categories/${categoryId}`)}
+          onMoreBtnClickHandler={() => router.push(`/categories/${categoryId}`)}
         >
           {name}
         </ContainerHeader>

--- a/client/src/components/templates/ProductsByCategoryContainer/styled.tsx
+++ b/client/src/components/templates/ProductsByCategoryContainer/styled.tsx
@@ -3,7 +3,9 @@ import styled from 'styled-components';
 export const ProductsByCategoryContainer = styled.div`
   width: 100%;
   background-color: white;
-  margin-bottom: 3px;
+  margin-bottom: 10px;
+  color: rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 0px 5px;
 
   & .wrapper {
     padding: 0 1rem;

--- a/client/src/components/templates/SlidableContainer/styled.tsx
+++ b/client/src/components/templates/SlidableContainer/styled.tsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
 
 export const SlidableContainer = styled.div`
-  margin-top: 3px;
   background-color: white;
+  margin-bottom: 10px;
+  color: rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 0px 5px;
+
   & .content {
     display: -webkit-box;
     width: 100%;

--- a/client/src/components/templates/SubCategoryNavContainer/SubCategoryNavContainer.tsx
+++ b/client/src/components/templates/SubCategoryNavContainer/SubCategoryNavContainer.tsx
@@ -21,7 +21,7 @@ export const SubCategoryNavContainer: React.FC<Props> = ({ subCategories }) => {
           return (
             <S.SubCategory
               key={`sub-category-nav-${subCategory.id}`}
-              onClick={() => router.replace(`/sub-categories/${subCategory.id}`)}
+              onClick={() => router.push(`/sub-categories/${subCategory.id}`)}
             >
               {subCategory.name}
             </S.SubCategory>

--- a/client/src/components/templates/SubCategoryNavContainer/styled.tsx
+++ b/client/src/components/templates/SubCategoryNavContainer/styled.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 export const SubCategoryNavContainer = styled.div<{}>`
   background: #fff;
   margin: 1rem 0;
+  color: rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 0px 5px;
 
   & .wrapper {
     display: grid;
@@ -10,6 +12,7 @@ export const SubCategoryNavContainer = styled.div<{}>`
     grid-auto-flow: row;
     border-top: 1px solid #efefef;
     border-bottom: 1px solid #efefef;
+    color: black;
   }
 `;
 

--- a/client/src/components/templates/TabViewContainer/styled.tsx
+++ b/client/src/components/templates/TabViewContainer/styled.tsx
@@ -3,8 +3,11 @@ import styled from 'styled-components';
 export const TabViewContainer = styled.div`
   display: flex;
   flex-direction: column;
-  margin-top: 3px;
   background-color: white;
+  margin-bottom: 10px;
+  color: rgba(0, 0, 0, 0.25);
+  box-shadow: 0px 0px 5px;
+
   & .content {
     padding: 0 1rem;
   }

--- a/client/src/pages/categories/[id].tsx
+++ b/client/src/pages/categories/[id].tsx
@@ -43,7 +43,7 @@ const CartegoryPage: NextPage<Props> = (props) => {
       main: { type: HeaderMainType.TEXT, content: `${props.name}` },
       right: [
         { type: 'Search', onClick: () => alert('검색') },
-        { type: 'Bars', onClick: () => router.replace('/signin') },
+        { type: 'Bars', onClick: () => router.push('/signin') },
       ],
     },
   };

--- a/client/src/pages/categories/[id].tsx
+++ b/client/src/pages/categories/[id].tsx
@@ -3,7 +3,6 @@ import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
 import Layout, { LayoutProps } from '@commons/Layout';
 import Banner from '@components/modules/Banner';
 import {
-  IconType,
   HeaderMainType,
   MaxCategoryCount,
   MaxProductsCountByCategoryPageContainer,

--- a/client/src/pages/favorite/index.tsx
+++ b/client/src/pages/favorite/index.tsx
@@ -13,7 +13,7 @@ type Props = {
 
 type FavoriteType = {};
 
-const FavoritePage: NextPage<Props> = (props) => {
+const FavoritePage: NextPage<Props> = () => {
   const router = useRouter();
   const { select } = useContext(Context);
 

--- a/client/src/pages/favorite/index.tsx
+++ b/client/src/pages/favorite/index.tsx
@@ -31,7 +31,7 @@ const FavoritePage: NextPage<Props> = (props) => {
       main: { type: HeaderMainType.TEXT, content: '찜한상품' },
       right: [
         { type: 'Search', onClick: () => alert('검색') },
-        { type: 'Bars', onClick: () => router.replace('/menu') },
+        { type: 'Bars', onClick: () => router.push('/menu') },
       ],
     },
   };

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -100,6 +100,10 @@ const MainPage: NextPage<Props> = (props) => {
       <TabViewContainer products={props.highestOffProducts} />
       <Banner />
       <FetchableContainer title="지금 뭐 먹지?" products={props.latestProducts} />
+      <SlidableContainer title="새로 나왔어요" products={props.latestProducts} />
+      <SlidableContainer title="요즘 잘팔려요" products={props.latestProducts} />
+      <FetchableContainer title="지금 필요한 생필품!" products={props.latestProducts} />
+      <Banner />
       {props.categories.map((category, idx) => (
         <ProductsByCategoryContainer
           key={idx}

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -7,6 +7,7 @@ import CategoryContainer, { CategoryType } from '@components/templates/CategoryC
 import SlidableContainer from '@components/templates/SlidableContainer';
 import ToastModal from '@components/modules/ToastModal';
 import TabViewContainer from '@components/templates/TabViewContainer';
+import FetchableContainer from '@components/templates/FetchableContainer';
 import ProductsByCategoryContainer from '@components/templates/ProductsByCategoryContainer';
 import API from '@utils/API';
 import HttpStatus from 'http-status';
@@ -98,6 +99,7 @@ const MainPage: NextPage<Props> = (props) => {
       />
       <TabViewContainer products={props.highestOffProducts} />
       <Banner />
+      <FetchableContainer title="지금 뭐 먹지?" products={props.latestProducts} />
       {props.categories.map((category, idx) => (
         <ProductsByCategoryContainer
           key={idx}

--- a/client/src/pages/sub-categories/[id].tsx
+++ b/client/src/pages/sub-categories/[id].tsx
@@ -30,11 +30,11 @@ const SubCartegoryPage: NextPage<Props> = (props) => {
   const layoutProps: LayoutProps = {
     title: `${props.name}`,
     headerProps: {
-      left: IconType.ARROW_LEFT,
+      left: 'ArrowLeft',
       main: { type: HeaderMainType.TEXT, content: `${props.name}` },
       right: [
-        { type: IconType.SEARCH, onClick: () => alert('검색') },
-        { type: IconType.BARS, onClick: () => router.push('/signin') },
+        { type: 'Search', onClick: () => alert('검색') },
+        { type: 'Bars', onClick: () => router.push('/signin') },
       ],
     },
   };

--- a/client/src/pages/sub-categories/[id].tsx
+++ b/client/src/pages/sub-categories/[id].tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useContext } from 'react';
 import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
 import Layout, { LayoutProps } from '@commons/Layout';
 import {
-  IconType,
   HeaderMainType,
   MaxProductsCountBySubCategoryPageContainer,
   MaxSubCategoryCount,

--- a/client/src/pages/sub-categories/[id].tsx
+++ b/client/src/pages/sub-categories/[id].tsx
@@ -34,7 +34,7 @@ const SubCartegoryPage: NextPage<Props> = (props) => {
       main: { type: HeaderMainType.TEXT, content: `${props.name}` },
       right: [
         { type: IconType.SEARCH, onClick: () => alert('검색') },
-        { type: IconType.BARS, onClick: () => router.replace('/signin') },
+        { type: IconType.BARS, onClick: () => router.push('/signin') },
       ],
     },
   };


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

fetchable container 컴포넌트 UI를 만들고 컨테이너별 스타일을 수정했습니다. 

메인 페이지에 필요한 컴포넌트 목록들을 모두 추가했습니다.
메인페이지에 스타일링을 수정했습니다.

TODO: 
- 이후 각 컴포넌트에 맞는 데이터를 불러와야합니다.
- fetchable container의 기능을 구현해야합니다.
 
<img width="320" src="https://user-images.githubusercontent.com/48426991/91432271-742efc80-e89c-11ea-97c1-1d0205e9f850.png">

## 체크리스트

### 리뷰어 1 - 이종구

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #164 
