### PR TITLE
feat: CartIcon 추가 #182

### DIFF
--- a/client/src/components/modules/CartIcon/CartIcon.tsx
+++ b/client/src/components/modules/CartIcon/CartIcon.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import * as S from './styled';
+import Icon from '@components/atoms/Icon';
+import { useRouter } from 'next/router';
+import { getCookie } from '@utils/cookie-manager';
+import { Context } from '@commons/Context';
+
+type Props = {};
+
+export const CartIcon: React.FC<Props> = () => {
+  const { cartProducts } = useContext(Context);
+  const router = useRouter();
+  const token = getCookie('authorization');
+  const onCartIconClickHandler = () => {
+    if (!token) {
+      confirm('로그인 하시겠습니까?') ? router.push('/signin') : false;
+      return;
+    }
+    router.push('/cart');
+  };
+
+  return (
+    <S.CartIcon onClick={onCartIconClickHandler}>
+      <Icon icon={'Basket'} size={5}></Icon>
+      <S.Badge>{cartProducts.length}</S.Badge>
+    </S.CartIcon>
+  );
+};

--- a/client/src/components/modules/CartIcon/CartIcon.tsx
+++ b/client/src/components/modules/CartIcon/CartIcon.tsx
@@ -22,7 +22,7 @@ export const CartIcon: React.FC<Props> = () => {
   return (
     <S.CartIcon onClick={onCartIconClickHandler}>
       <Icon icon={'Basket'} size={5}></Icon>
-      <S.Badge>{cartProducts.length}</S.Badge>
+      <S.Badge>{cartProducts.reduce((prev, cur) => prev + cur.count, 0)}</S.Badge>
     </S.CartIcon>
   );
 };

--- a/client/src/components/modules/CartIcon/index.tsx
+++ b/client/src/components/modules/CartIcon/index.tsx
@@ -1,0 +1,3 @@
+import { CartIcon } from './CartIcon';
+
+export default CartIcon;

--- a/client/src/components/modules/CartIcon/styled.tsx
+++ b/client/src/components/modules/CartIcon/styled.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+export const CartIcon = styled.div<{}>`
+  position: relative;
+  background-color: #2cc0bd;
+  width: 10rem;
+  height: 10rem;
+  border-radius: 9999px;
+  position: fixed;
+  bottom: 3rem;
+  right: 3rem;
+  box-shadow: 0 3px 20px -2px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  & i {
+    color: white;
+  }
+`;
+
+export const Badge = styled.div<{}>`
+  position: absolute;
+  background-color: white;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 9999px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transform: translate(80%, -80%);
+  color: #2cc0bd;
+  font-size: 1.5rem;
+  font-weight: 700;
+`;

--- a/client/src/pages/categories/[id].tsx
+++ b/client/src/pages/categories/[id].tsx
@@ -23,6 +23,7 @@ import { Context } from '@commons/Context';
 import { useRouter } from 'next/router';
 import * as S from '@commons/styles/ProductsContainerStyled';
 import SubCategoryNavContainer from '@components/templates/SubCategoryNavContainer';
+import CartIcon from '@components/modules/CartIcon';
 
 type Props = {
   id: number;
@@ -62,6 +63,7 @@ const CartegoryPage: NextPage<Props> = (props) => {
       <S.ProductsContainerStyle>
         <ProductsByCategoryContainer products={props.products} headerType="filter" />
       </S.ProductsContainerStyle>
+      <CartIcon />
       <ToastModal />
     </Layout>
   );

--- a/client/src/pages/favorite/index.tsx
+++ b/client/src/pages/favorite/index.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import FavoriteContainer from '@components/templates/FavoriteContainer';
 import ToastModal from '@components/modules/ToastModal';
 import { Context } from '@commons/Context';
+import CartIcon from '@components/modules/CartIcon';
 
 type Props = {
   favorites: Array<FavoriteType>;
@@ -39,6 +40,7 @@ const FavoritePage: NextPage<Props> = () => {
   return (
     <Layout title={layoutProps.title} headerProps={layoutProps.headerProps}>
       <FavoriteContainer />
+      <CartIcon />
       <ToastModal />
     </Layout>
   );

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -6,6 +6,7 @@ import Banner from '@components/modules/Banner';
 import CategoryContainer, { CategoryType } from '@components/templates/CategoryContainer';
 import SlidableContainer from '@components/templates/SlidableContainer';
 import ToastModal from '@components/modules/ToastModal';
+import CartIcon from '@components/modules/CartIcon';
 import TabViewContainer from '@components/templates/TabViewContainer';
 import FetchableContainer from '@components/templates/FetchableContainer';
 import ProductsByCategoryContainer from '@components/templates/ProductsByCategoryContainer';
@@ -100,6 +101,7 @@ const MainPage: NextPage<Props> = (props) => {
           headerType="main"
         />
       ))}
+      <CartIcon />
       <ToastModal />
     </Layout>
   );

--- a/client/src/pages/sub-categories/[id].tsx
+++ b/client/src/pages/sub-categories/[id].tsx
@@ -15,6 +15,7 @@ import { Context } from '@commons/Context';
 import { useRouter } from 'next/router';
 import * as S from '@commons/styles/ProductsContainerStyled';
 import { SubCategoryType } from '@pages/index';
+import CartIcon from '@components/modules/CartIcon';
 
 type Props = {
   id: number;
@@ -51,6 +52,7 @@ const SubCartegoryPage: NextPage<Props> = (props) => {
         <ProductsByCategoryContainer products={props.products} headerType="filter" />
       </S.ProductsContainerStyle>
       <ToastModal />
+      <CartIcon />
     </Layout>
   );
 };


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

카트 아이콘을 간단히 추가하였습니다.
메인, 카테고리, 서브카테고리, 찜하기 페이지에 카트아이콘을 추가하였습니다.
주문 내역 페이지가 완성되면 이곳에도 카트아이콘을 추가 예정입니다.

<img width="320" src="https://user-images.githubusercontent.com/48426991/91491661-56d74e00-e8ef-11ea-91d4-bd131ca14371.png">

## 체크리스트

### 리뷰어 1 - 이종구

- [x] 리뷰 중입니다.
- [x] 코드를 실행했을 때 잘 동작합니다.
- [x] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #182 
