### PR TITLE
feat: safari 지원을 위한 scroll-smooth polyfill 적용 #134

### DIFF
--- a/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
+++ b/client/src/components/modules/CarouselBanner/CarouselBanner.tsx
@@ -29,8 +29,8 @@ export const CarouselBanner = () => {
   const initBannerWidth = () => {
     const container = containerRef.current as HTMLDivElement;
 
-    container.style.scrollBehavior = 'initial';
-    container.scrollLeft += innerWidth;
+    const left = container.scrollLeft + innerWidth;
+    container.scroll({ left, behavior: 'auto' });
   };
 
   const removeUselessIndicators = () => {
@@ -73,13 +73,11 @@ export const CarouselBanner = () => {
     const { scrollWidth, scrollLeft } = container;
 
     if (scrollWidth - innerWidth - scrollLeft <= 0) {
-      container.style.scrollBehavior = 'initial';
-      container.scrollLeft = innerWidth;
+      container.scroll({ left: innerWidth, behavior: 'auto' });
       container.style.scrollBehavior = 'smooth';
     }
     if (scrollLeft <= 0) {
-      container.style.scrollBehavior = 'initial';
-      container.scrollLeft = scrollWidth - 2 * innerWidth;
+      container.scroll({ left: scrollWidth - 2 * innerWidth, behavior: 'auto' });
       container.style.scrollBehavior = 'smooth';
     }
   };
@@ -107,8 +105,8 @@ export const CarouselBanner = () => {
     () => {
       const container = containerRef.current as HTMLDivElement;
 
-      container.style.scrollBehavior = 'smooth';
-      container.scrollLeft += innerWidth;
+      const left = container.scrollLeft + innerWidth;
+      container.scroll({ left, behavior: 'smooth' });
     },
     isRunning ? delay : null
   );

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -23,6 +23,11 @@ import {
 import { Context } from '@commons/Context';
 import { useRouter } from 'next/router';
 import DynamicContainer from '@components/templates/DynamicContainer';
+import smoothscroll from 'smoothscroll-polyfill';
+
+if (typeof window !== 'undefined') {
+  smoothscroll.polyfill();
+}
 
 export type ProductType = {
   id: number;

--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "typescript": "^3.9.7"
+  },
+  "dependencies": {
+    "@types/smoothscroll-polyfill": "0.3.1",
+    "smoothscroll-polyfill": "0.4.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/smoothscroll-polyfill@0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@types/smoothscroll-polyfill/-/smoothscroll-polyfill-0.3.1.tgz#77fb3a6e116bdab4a5959122e3b8e201224dcd49"
+  integrity sha512-+KkHw4y+EyeCtVXET7woHUhIbfWFCflc0E0mZnSV+ZdjPQeHt/9KPEuT7gSW/kFQ8O3EG30PLO++YhChDt8+Ag==
+
 ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
@@ -266,6 +271,11 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+smoothscroll-polyfill@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.4.tgz#3a259131dc6930e6ca80003e1cb03b603b69abf8"
+  integrity sha512-TK5ZA9U5RqCwMpfoMq/l1mrH0JAR7y7KRvOBx0n2869aLxch+gT9GhN3yUfjiw+d/DiF1mKo14+hd62JyMmoBg==
 
 spawn-command@^0.0.2-1:
   version "0.0.2-1"


### PR DESCRIPTION
## PR 요약

> 해당 PR이 어떤 PR인지에 대한 간략한 설명을 추가합니다.

- safari에서 캐로셀 배너 자동 스크롤시 `scroll-behavior: smooth` 를 적용하기 위한 폴리필 적용.
- 서버 사이드 렌더링 시에 폴리필 라이브러리의 window 를 찾지 못하는 문제는 다음으로 해결.

```js
if (typeof window !== 'undefined') {
  smoothscroll.polyfill();
}
```

- 라이브러리의 사용법대로 스크롤 변경해야 적용 가능.

```js
container.style.scrollBehavior = 'smooth';
container.scrollLeft += innerWidth;
```

->

```js
const left = container.scrollLeft + innerWidth;
element.scroll({ top: 0, left: 0, behavior: 'smooth' });`
```

## 체크리스트

### 리뷰어 1

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

### 리뷰어 2

- [ ] 리뷰 중입니다.
- [ ] 코드를 실행했을 때 잘 동작합니다.
- [ ] 리뷰 완료 했습니다.

## 관련 이슈

> 이 PR이 머지되었을 때 closed될 이슈의 번호를 지정합니다.

- resolve #134 

## 참고자료

> 해당 PR과 관련된 자료가 있다면 추가합니다.

🔗 [smooth scroll behavior polyfill](http://iamdustan.com/smoothscroll/)
🔗 [Server-Side Rendering (SSR) - avoids "ReferenceError: window is not defined" #97](https://github.com/iamdustan/smoothscroll/pull/97#issuecomment-368303423)

## 기타(스크린샷 등)

> PR에 대한 이해를 돕기 위한 자료가 있다면 추가합니다.
